### PR TITLE
feat(shavit-mark): add paint save/load/delete using shavit database

### DIFF
--- a/addons/sourcemod/scripting/shavit-mark.sp
+++ b/addons/sourcemod/scripting/shavit-mark.sp
@@ -166,7 +166,7 @@ enum struct PaintData
 public Plugin myinfo =
 {
     name        = "[shavit-surf] Mark",
-    author      = "SlidyBat, Ciallo-Ani, KikI",
+    author      = "SlidyBat, Ciallo-Ani, KikI, Nora",
     description = "Allow players to mark a position with decals or ping markers.",
     version     = "4.0",
     url         = "https://github.com/bhopppp/Shavit-Surf-Timer"

--- a/addons/sourcemod/scripting/shavit-mark.sp
+++ b/addons/sourcemod/scripting/shavit-mark.sp
@@ -32,6 +32,7 @@
 #pragma semicolon 1
 
 #define PAINT_DISTANCE_SQ 1.0
+#define DECAL_LIMIT       192    // r_decals is 200 by default in cs:s I wish we could've use clientcommand to change it
 
 #define MENU_PAINT 1
 #define MENU_PING 2
@@ -1400,6 +1401,12 @@ void AddPaint(int client, float pos[3], int paint = 0, int size = 0)
 		paint = GetRandomInt(1, sizeof(gS_PaintColors) - 1);
 	}
 
+	// Remove oldest paint if at limit (engine removes oldest decal automatically)
+	while (g_hPaintData[client].Length >= DECAL_LIMIT)
+	{
+		g_hPaintData[client].Erase(0);
+	}
+
     PaintData data;
     data.x     = pos[0];
     data.y     = pos[1];
@@ -1618,6 +1625,12 @@ public Action Command_PaintSave(int client, int args)
         return Plugin_Handled;
     }
 
+    if (g_hPendingPaints[client] != null)
+    {
+        Shavit_PrintToChat(client, "Cannot save while loading paints.");
+        return Plugin_Handled;
+    }
+
     if (g_hPaintData[client] == null || g_hPaintData[client].Length == 0)
     {
         Shavit_PrintToChat(client, "You have no paints to save.");
@@ -1692,6 +1705,12 @@ public Action Command_PaintLoad(int client, int args)
     if (gH_SQL == null)
     {
         Shavit_PrintToChat(client, "Database not connected.");
+        return Plugin_Handled;
+    }
+
+    if (g_hPendingPaints[client] != null)
+    {
+        Shavit_PrintToChat(client, "Already loading paints, please wait.");
         return Plugin_Handled;
     }
 

--- a/addons/sourcemod/scripting/shavit-mark.sp
+++ b/addons/sourcemod/scripting/shavit-mark.sp
@@ -1,7 +1,7 @@
 /*
  * shavit's Surf Timer - Mark
  * by: SlidyBat, Ciallo-Ani, KikI
- * 
+ *
  * Ping mark implementation reference: https://github.com/DeadSurfer/trikz/blob/main/pingmark.sp
  *
  * This file is part of shavit's Surf Timer (https://github.com/shavitush/bhoptimer)
@@ -31,118 +31,118 @@
 #pragma newdecls required
 #pragma semicolon 1
 
-#define PAINT_DISTANCE_SQ 1.0
-#define DECAL_LIMIT       192    // r_decals is 200 by default in cs:s I wish we could've use clientcommand to change it
+#define DECAL_LIMIT              192    // r_decals is 200 by default in cs:s I wish we could've use clientcommand to change it
+#define PAINT_SAVE_LOAD_COOLDOWN 5.0
 
-#define MENU_PAINT 1
-#define MENU_PING 2
+#define MENU_PAINT               1
+#define MENU_PING                2
 
-#define RESPONSE_ACCEPT 1
-#define RESPONSE_DECLINE 2
-#define RESPONSE_CANCEL 3
+#define RESPONSE_ACCEPT          1
+#define RESPONSE_DECLINE         2
+#define RESPONSE_CANCEL          3
 
-#define PING_MODEL_PATH "models/expert_zone/pingtool/pingtool.mdl"
-#define PING_SOUND_PATH "expert_zone/pingtool/click.wav"
+#define PING_MODEL_PATH          "models/expert_zone/pingtool/pingtool.mdl"
+#define PING_SOUND_PATH          "expert_zone/pingtool/click.wav"
 
 /* Colour name, file name */
 char gS_PaintColors[][][64] =    // Modify this to add/change colours
-{
-	{"ColorRandom",     	"random"         },
-	{"ColorWhite",      	"paint_white"    },
-	{"ColorBlack",      	"paint_black"    },
-	{"ColorBlue",       	"paint_blue"     },
-	{"ColorLightBlue", 		"paint_lightblue"},
-	{"ColorBrown",      	"paint_brown"    },
-	{"ColorCyan",       	"paint_cyan"     },
-	{"ColorGreen",      	"paint_green"    },
-	{"ColorDarkGreen", 		"paint_darkgreen"},
-	{"ColorRed",        	"paint_red"      },
-	{"ColorOrange",     	"paint_orange"   },
-	{"ColorYellow",     	"paint_yellow"   },
-	{"ColorPink",       	"paint_pink"     },
-	{"ColorLightPink", 		"paint_lightpink"},
-	{"ColorPurple",     	"paint_purple"   },
+    {
+        {"ColorRandom",     "random"         },
+        { "ColorWhite",     "paint_white"    },
+        { "ColorBlack",     "paint_black"    },
+        { "ColorBlue",      "paint_blue"     },
+        { "ColorLightBlue", "paint_lightblue"},
+        { "ColorBrown",     "paint_brown"    },
+        { "ColorCyan",      "paint_cyan"     },
+        { "ColorGreen",     "paint_green"    },
+        { "ColorDarkGreen", "paint_darkgreen"},
+        { "ColorRed",       "paint_red"      },
+        { "ColorOrange",    "paint_orange"   },
+        { "ColorYellow",    "paint_yellow"   },
+        { "ColorPink",      "paint_pink"     },
+        { "ColorLightPink", "paint_lightpink"},
+        { "ColorPurple",    "paint_purple"   },
 };
 
-char gS_PingColors[][][64] =
-{
-	{"ColorTurquoise",	 	"134;226;213;150"},
-    {"ColorWhite",       	"255;255;255;150"},
-    {"ColorBlue",        	"40;120;255;150"},
-    {"ColorGreen",       	"0;230;64;150"},
-    {"ColorRed",         	"255;60;60;150"},
-    {"ColorOrange",      	"255;125;35;150"},
-    {"ColorYellow",      	"255;235;0;150"},
-    {"ColorPink",        	"255;192;203;150"},
-    {"ColorPurple",      	"168;70;228;150"},
-    {"ColorCyan",        	"0;255;255;150"},
+char gS_PingColors[][][64] = {
+    {"ColorTurquoise", "134;226;213;150"},
+    { "ColorWhite",    "255;255;255;150"},
+    { "ColorBlue",     "40;120;255;150" },
+    { "ColorGreen",    "0;230;64;150"   },
+    { "ColorRed",      "255;60;60;150"  },
+    { "ColorOrange",   "255;125;35;150" },
+    { "ColorYellow",   "255;235;0;150"  },
+    { "ColorPink",     "255;192;203;150"},
+    { "ColorPurple",   "168;70;228;150" },
+    { "ColorCyan",     "0;255;255;150"  },
 };
 
 /* Size name, size suffix */
 char gS_PaintSizes[][][64] =    // Modify this to add more sizes
-{
-	{"PaintSizeSmall",  ""      },
-	{"PaintSizeMedium", "_med"  },
-	{"PaintSizeLarge",  "_large"},
+    {
+        {"PaintSizeSmall",   ""      },
+        { "PaintSizeMedium", "_med"  },
+        { "PaintSizeLarge",  "_large"},
 };
 
-int gI_Sprites[sizeof(gS_PaintColors) - 1][sizeof(gS_PaintSizes)];
-int gI_Eraser[sizeof(gS_PaintSizes)];
-int gI_LastOpenedMenu[MAXPLAYERS + 1];
+int           gI_Sprites[sizeof(gS_PaintColors) - 1][sizeof(gS_PaintSizes)];
+int           gI_Eraser[sizeof(gS_PaintSizes)];
+int           gI_LastOpenedMenu[MAXPLAYERS + 1];
 
 // Player Paint info
-bool gB_ErasePaint[MAXPLAYERS + 1];
-bool gB_IsPainting[MAXPLAYERS + 1];
-float gF_LastPaint[MAXPLAYERS + 1][3];
+bool          gB_ErasePaint[MAXPLAYERS + 1];
+bool          gB_IsPainting[MAXPLAYERS + 1];
+float         gF_LastPaint[MAXPLAYERS + 1][3];
 
 // Player Ping info
-int gI_PingEntity[2048] = {-1, ...};
-int gI_PlayerPing[MAXPLAYERS + 1];
-int gI_PlayerLastPing[MAXPLAYERS + 1];
-Handle gH_PingTimer[MAXPLAYERS + 1];
+int           gI_PingEntity[2048] = { -1, ... };
+int           gI_PlayerPing[MAXPLAYERS + 1];
+int           gI_PlayerLastPing[MAXPLAYERS + 1];
+Handle        gH_PingTimer[MAXPLAYERS + 1];
 
 // Player Partner info
-int gI_Partner[MAXPLAYERS + 1];
-int gI_Partnering[MAXPLAYERS + 1];
+int           gI_Partner[MAXPLAYERS + 1];
+int           gI_Partnering[MAXPLAYERS + 1];
 
 // Player Partner Setting
-bool gB_ReciveRequest[MAXPLAYERS + 1];
+bool          gB_ReciveRequest[MAXPLAYERS + 1];
 
 // Paint Settings
-int gI_PlayerPaintColor[MAXPLAYERS + 1];
-int gI_PlayerPaintSize[MAXPLAYERS + 1];
-bool gB_PaintToAll[MAXPLAYERS + 1];
-bool gB_PaintMode[MAXPLAYERS + 1];
+int           gI_PlayerPaintColor[MAXPLAYERS + 1];
+int           gI_PlayerPaintSize[MAXPLAYERS + 1];
+bool          gB_PaintToAll[MAXPLAYERS + 1];
+bool          gB_PaintMode[MAXPLAYERS + 1];
 
 // Ping Settings
-int gI_PingColor[MAXPLAYERS + 1];
-bool gB_PingSound[MAXPLAYERS + 1];
-bool gB_PingDuration[MAXPLAYERS + 1];	// True - Until next ping 		False - Only few seconds
-bool gB_PingToAll[MAXPLAYERS + 1];
+int           gI_PingColor[MAXPLAYERS + 1];
+bool          gB_PingSound[MAXPLAYERS + 1];
+bool          gB_PingDuration[MAXPLAYERS + 1];    // True - Until next ping 		False - Only few seconds
+bool          gB_PingToAll[MAXPLAYERS + 1];
 
 // Global Variables
-int gI_Tickrate;
-int gI_PingIntervalTick;
-bool gB_Late = false;
+int           gI_Tickrate;
+int           gI_PingIntervalTick;
+bool          gB_Late = false;
 
 chatstrings_t gS_ChatStrings;
 
 /* COOKIES */
-Cookie gH_PlayerPaintColor;
-Cookie gH_PlayerPaintSize;
-Cookie gH_PlayerReciveRequest;
-Cookie gH_PlayerPaintMode;
+Cookie        gH_PlayerPaintColor;
+Cookie        gH_PlayerPaintSize;
+Cookie        gH_PlayerReciveRequest;
+Cookie        gH_PlayerPaintMode;
 
-Cookie gH_PlayerPingDuration;
-Cookie gH_PlayerPingSound;
-Cookie gH_PlayerPingColor;
+Cookie        gH_PlayerPingDuration;
+Cookie        gH_PlayerPingSound;
+Cookie        gH_PlayerPingColor;
 
 /* CONVARS */
-Convar gCV_AccessFlag;
-Convar gCV_PingDuration;
-Convar gCV_PingInterval;
+Convar        gCV_AccessFlag;
+Convar        gCV_PingDuration;
+Convar        gCV_PingInterval;
 
 /* DATABASE & SAVE */
+float         g_fLastSaveLoad[MAXPLAYERS + 1];
 Database      gH_SQL;
 int           gI_Driver;
 char          gS_MySQLPrefix[32];
@@ -162,143 +162,146 @@ enum struct PaintData
 
 public Plugin myinfo =
 {
-	name = "[shavit-surf] Mark",
-	author = "SlidyBat, Ciallo-Ani, KikI",
-	description = "Allow players to mark a position with decals or ping markers.",
-	version = "4.0",
-	url = "https://github.com/bhopppp/Shavit-Surf-Timer"
+    name        = "[shavit-surf] Mark",
+    author      = "SlidyBat, Ciallo-Ani, KikI",
+    description = "Allow players to mark a position with decals or ping markers.",
+    version     = "4.0",
+    url         = "https://github.com/bhopppp/Shavit-Surf-Timer"
+
+
 }
 
-public void OnPluginStart()
+public void
+    OnPluginStart()
 {
-	/* Register Cookies */
-	gH_PlayerPaintColor = new Cookie("mark_playerpaintcolor", "mark_playerpaintcolor", CookieAccess_Protected);
-	gH_PlayerPaintSize = new Cookie("mark_playerpaintsize", "mark_playerpaintsize", CookieAccess_Protected);
-	gH_PlayerPaintMode = new Cookie("mark_playerpaintmode", "mark_playerpaintmode", CookieAccess_Protected);
-	gH_PlayerReciveRequest = new Cookie("mark_playerreciverequest", "mark_playerreciverequest", CookieAccess_Protected);
+    /* Register Cookies */
+    gH_PlayerPaintColor    = new Cookie("mark_playerpaintcolor", "mark_playerpaintcolor", CookieAccess_Protected);
+    gH_PlayerPaintSize     = new Cookie("mark_playerpaintsize", "mark_playerpaintsize", CookieAccess_Protected);
+    gH_PlayerPaintMode     = new Cookie("mark_playerpaintmode", "mark_playerpaintmode", CookieAccess_Protected);
+    gH_PlayerReciveRequest = new Cookie("mark_playerreciverequest", "mark_playerreciverequest", CookieAccess_Protected);
 
-	gH_PlayerPingDuration = new Cookie("paint_playerpingduration", "paint_playerpingduration", CookieAccess_Protected);
-	gH_PlayerPingSound = new Cookie("paint_playerpingsound", "paint_playerpingsound", CookieAccess_Protected);
-	gH_PlayerPingColor = new Cookie("paint_playerpingcolor", "paint_playerpingcolor", CookieAccess_Protected);
+    gH_PlayerPingDuration  = new Cookie("paint_playerpingduration", "paint_playerpingduration", CookieAccess_Protected);
+    gH_PlayerPingSound     = new Cookie("paint_playerpingsound", "paint_playerpingsound", CookieAccess_Protected);
+    gH_PlayerPingColor     = new Cookie("paint_playerpingcolor", "paint_playerpingcolor", CookieAccess_Protected);
 
-	gCV_AccessFlag = new Convar("shavit_mark_displaytoall_accessflag", "", "Admin flag to require privileges for send decals or ping markers to all players", 0, false, 0.0, false, 0.0);
-	gCV_PingDuration = new Convar("shavit_mark_pingduration", "4.0", "The duration time (in seconds) of ping marks\n 0.0 - Until next ping marks created", 0, true, 0.0, true, 20.0);
-	gCV_PingInterval = new Convar("shavit_mark_pinginterval", "0.5", "The minimum time interval (in seconds) between two ping marks", 0, true, 0.1, true, 5.0);
-	Convar.AutoExecConfig();
+    gCV_AccessFlag         = new Convar("shavit_mark_displaytoall_accessflag", "", "Admin flag to require privileges for send decals or ping markers to all players", 0, false, 0.0, false, 0.0);
+    gCV_PingDuration       = new Convar("shavit_mark_pingduration", "4.0", "The duration time (in seconds) of ping marks\n 0.0 - Until next ping marks created", 0, true, 0.0, true, 20.0);
+    gCV_PingInterval       = new Convar("shavit_mark_pinginterval", "0.5", "The minimum time interval (in seconds) between two ping marks", 0, true, 0.1, true, 5.0);
+    Convar.AutoExecConfig();
 
-	gCV_PingInterval.AddChangeHook(OnConVarChanged);
+    gCV_PingInterval.AddChangeHook(OnConVarChanged);
 
-	gI_Tickrate = RoundToNearest(1.0 / GetTickInterval());
+    gI_Tickrate = RoundToNearest(1.0 / GetTickInterval());
 
-	/* COMMANDS */
-	RegConsoleCmd("+paint", Command_EnablePaint, "Start Painting");
-	RegConsoleCmd("-paint", Command_DisablePaint, "Stop Painting");
-	RegConsoleCmd("sm_paint", Command_Paint, "Open a paint menu for a client");
-	RegConsoleCmd("sm_paintcolour", Command_PaintColour, "Open a paint color menu for a client");
-	RegConsoleCmd("sm_paintcolor", Command_PaintColour, "Open a paint color menu for a client");
-	RegConsoleCmd("sm_paintsize", Command_PaintSize, "Open a paint size menu for a client");
-	RegConsoleCmd("sm_paintmode", Command_PaintMode, "Toggle paint mode for a client");
-	RegConsoleCmd("sm_painteraser", Command_PaintErase, "Toggle paint eraser for a client");
+    /* COMMANDS */
+    RegConsoleCmd("+paint", Command_EnablePaint, "Start Painting");
+    RegConsoleCmd("-paint", Command_DisablePaint, "Stop Painting");
+    RegConsoleCmd("sm_paint", Command_Paint, "Open a paint menu for a client");
+    RegConsoleCmd("sm_paintcolour", Command_PaintColour, "Open a paint color menu for a client");
+    RegConsoleCmd("sm_paintcolor", Command_PaintColour, "Open a paint color menu for a client");
+    RegConsoleCmd("sm_paintsize", Command_PaintSize, "Open a paint size menu for a client");
+    RegConsoleCmd("sm_paintmode", Command_PaintMode, "Toggle paint mode for a client");
+    RegConsoleCmd("sm_painteraser", Command_PaintErase, "Toggle paint eraser for a client");
 
-	RegConsoleCmd("sm_ping", Command_Ping, "Ping the position where player aiming at");
-	RegConsoleCmd("sm_pingmenu", Command_PingMenu, "Open a ping menu for a client");
-	RegConsoleCmd("sm_pingcolor", Command_PingColor, "Open a ping color menu for a client");
+    RegConsoleCmd("sm_ping", Command_Ping, "Ping the position where player aiming at");
+    RegConsoleCmd("sm_pingmenu", Command_PingMenu, "Open a ping menu for a client");
+    RegConsoleCmd("sm_pingcolor", Command_PingColor, "Open a ping color menu for a client");
 
-	RegConsoleCmd("sm_paintsave", Command_PaintSave, "Save your current paints");
-	RegConsoleCmd("sm_paintload", Command_PaintLoad, "Load your saved paints");
-	RegConsoleCmd("sm_paintdelete", Command_PaintDelete, "Delete your saved paints");
-	RegConsoleCmd("sm_savepaint", Command_PaintSave, "Save your current paints");
-	RegConsoleCmd("sm_loadpaint", Command_PaintLoad, "Load your saved paints");
-	RegConsoleCmd("sm_deletepaint", Command_PaintDelete, "Delete your saved paints");
+    RegConsoleCmd("sm_paintsave", Command_PaintSave, "Save your current paints");
+    RegConsoleCmd("sm_paintload", Command_PaintLoad, "Load your saved paints");
+    RegConsoleCmd("sm_paintdelete", Command_PaintDelete, "Delete your saved paints");
+    RegConsoleCmd("sm_savepaint", Command_PaintSave, "Save your current paints");
+    RegConsoleCmd("sm_loadpaint", Command_PaintLoad, "Load your saved paints");
+    RegConsoleCmd("sm_deletepaint", Command_PaintDelete, "Delete your saved paints");
 
-	LoadTranslations("shavit-common.phrases");
-	LoadTranslations("shavit-mark.phrases");
+    LoadTranslations("shavit-common.phrases");
+    LoadTranslations("shavit-mark.phrases");
 
-	/* Late loading */
-	for (int i = 1; i <= MaxClients; i++)
-	{
-		if (IsClientInGame(i))
-		{
-			OnClientCookiesCached(i);
-		}
-	}
+    /* Late loading */
+    for (int i = 1; i <= MaxClients; i++)
+    {
+        if (IsClientInGame(i))
+        {
+            OnClientCookiesCached(i);
+        }
+    }
 
-	if(gB_Late)
-	{
-		Shavit_OnChatConfigLoaded();
-		Shavit_OnDatabaseLoaded();
-	}
+    if (gB_Late)
+    {
+        Shavit_OnChatConfigLoaded();
+        Shavit_OnDatabaseLoaded();
+    }
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	gB_Late = late;
+    gB_Late = late;
 
-	return APLRes_Success;
+    return APLRes_Success;
 }
 
 public void OnClientCookiesCached(int client)
 {
-	if(!GetClientCookieInt(client, gH_PlayerPaintColor, gI_PlayerPaintColor[client]))
-	{
-		SetClientCookieInt(client, gH_PlayerPaintColor, 4);
-	}
+    if (!GetClientCookieInt(client, gH_PlayerPaintColor, gI_PlayerPaintColor[client]))
+    {
+        SetClientCookieInt(client, gH_PlayerPaintColor, 4);
+    }
 
-	if(!GetClientCookieInt(client, gH_PlayerPaintSize, gI_PlayerPaintSize[client]))
-	{
-		SetClientCookieInt(client, gH_PlayerPaintSize, 0);
-	}
+    if (!GetClientCookieInt(client, gH_PlayerPaintSize, gI_PlayerPaintSize[client]))
+    {
+        SetClientCookieInt(client, gH_PlayerPaintSize, 0);
+    }
 
-	if(!GetClientCookieBool(client, gH_PlayerPaintMode, gB_PaintMode[client]))
-	{
-		SetClientCookieBool(client, gH_PlayerPaintMode, false);
-	}
+    if (!GetClientCookieBool(client, gH_PlayerPaintMode, gB_PaintMode[client]))
+    {
+        SetClientCookieBool(client, gH_PlayerPaintMode, false);
+    }
 
-	if(!GetClientCookieBool(client, gH_PlayerPingSound, gB_PingSound[client]))
-	{
-		gB_PingSound[client] = true;
-		SetClientCookieBool(client, gH_PlayerPingSound, true);
-	}
+    if (!GetClientCookieBool(client, gH_PlayerPingSound, gB_PingSound[client]))
+    {
+        gB_PingSound[client] = true;
+        SetClientCookieBool(client, gH_PlayerPingSound, true);
+    }
 
-	if(!GetClientCookieBool(client, gH_PlayerPingDuration, gB_PingDuration[client]))
-	{
-		SetClientCookieBool(client, gH_PlayerPingDuration, false);
-	}
+    if (!GetClientCookieBool(client, gH_PlayerPingDuration, gB_PingDuration[client]))
+    {
+        SetClientCookieBool(client, gH_PlayerPingDuration, false);
+    }
 
-	if(!GetClientCookieInt(client, gH_PlayerPingColor, gI_PingColor[client]))
-	{
-		gI_PingColor[client] = 0;
-		SetClientCookieInt(client, gH_PlayerPingColor, 0);
-	}
+    if (!GetClientCookieInt(client, gH_PlayerPingColor, gI_PingColor[client]))
+    {
+        gI_PingColor[client] = 0;
+        SetClientCookieInt(client, gH_PlayerPingColor, 0);
+    }
 
-	if(!GetClientCookieBool(client, gH_PlayerReciveRequest, gB_ReciveRequest[client]))
-	{
-		gB_ReciveRequest[client] = true;
-		SetClientCookieBool(client, gH_PlayerReciveRequest, true);
-	}
+    if (!GetClientCookieBool(client, gH_PlayerReciveRequest, gB_ReciveRequest[client]))
+    {
+        gB_ReciveRequest[client] = true;
+        SetClientCookieBool(client, gH_PlayerReciveRequest, true);
+    }
 
-	gB_PingToAll[client] = false;
-	gB_PaintToAll[client] = false;
+    gB_PingToAll[client]  = false;
+    gB_PaintToAll[client] = false;
 
-	gI_Partner[client] = 0;
+    gI_Partner[client]    = 0;
 }
 
-public void OnConfigsExecuted() 
+public void OnConfigsExecuted()
 {
-	gI_PingIntervalTick = RoundToCeil(gCV_PingInterval.FloatValue * float(gI_Tickrate));
+    gI_PingIntervalTick = RoundToCeil(gCV_PingInterval.FloatValue * float(gI_Tickrate));
 }
 
 public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	if(StrEqual(oldValue, newValue))
-	{
-		return;
-	}
+    if (StrEqual(oldValue, newValue))
+    {
+        return;
+    }
 
-	if(convar == gCV_PingInterval)
-	{
-		gI_PingIntervalTick = RoundToCeil(gCV_PingInterval.FloatValue * float(gI_Tickrate));
-	}
+    if (convar == gCV_PingInterval)
+    {
+        gI_PingIntervalTick = RoundToCeil(gCV_PingInterval.FloatValue * float(gI_Tickrate));
+    }
 }
 
 public void OnMapStart()
@@ -312,31 +315,33 @@ public void OnMapStart()
         }
     }
 
-	char buffer[PLATFORM_MAX_PATH];
+    char buffer[PLATFORM_MAX_PATH];
 
-	for (int color = 1; color < sizeof(gS_PaintColors); color++)
-	{
-		for (int size = 0; size < sizeof(gS_PaintSizes); size++)
-		{
-			Format(buffer, sizeof(buffer), "decals/paint/%s%s.vmt", gS_PaintColors[color][1], gS_PaintSizes[size][1]);
-			gI_Sprites[color - 1][size] = PrecachePaint(buffer); // color - 1 because starts from [1], [0] is reserved for random
-		}
-	}
+    for (int color = 1; color < sizeof(gS_PaintColors); color++)
+    {
+        for (int size = 0; size < sizeof(gS_PaintSizes); size++)
+        {
+            Format(buffer, sizeof(buffer), "decals/paint/%s%s.vmt", gS_PaintColors[color][1], gS_PaintSizes[size][1]);
+            gI_Sprites[color - 1][size] = PrecachePaint(buffer);    // color - 1 because starts from [1], [0] is reserved for random
+        }
+    }
 
-	for (int size = 0; size < sizeof(gS_PaintSizes); size++)
-	{
-		Format(buffer, sizeof(buffer), "decals/paint/paint_eraser%s.vmt", gS_PaintSizes[size][1]);
-		gI_Eraser[size] = PrecachePaint(buffer); 
-	}
+    for (int size = 0; size < sizeof(gS_PaintSizes); size++)
+    {
+        Format(buffer, sizeof(buffer), "decals/paint/paint_eraser%s.vmt", gS_PaintSizes[size][1]);
+        gI_Eraser[size] = PrecachePaint(buffer);
+    }
 
-	AddFilesToDownloadsTable();
+    AddFilesToDownloadsTable();
 }
 
 public void OnClientConnected(int client)
 {
-	gI_PlayerPing[client] = 0;
-	gI_PingEntity[gI_PlayerPing[client]] = -1;
-	gI_PlayerLastPing[client] = 0;
+    gI_PlayerPing[client]                = 0;
+    gI_PingEntity[gI_PlayerPing[client]] = -1;
+    gI_PlayerLastPing[client]            = 0;
+
+    g_fLastSaveLoad[client]              = 0.0;
 
     delete g_hPaintData[client];
     g_hPaintData[client] = new ArrayList(sizeof(PaintData));
@@ -348,92 +353,92 @@ public void OnClientConnected(int client)
 
 public void OnMapEnd()
 {
-	for (int i = 0; i++; i <= MaxClients)
-	{
-		RemovePing(i);
-	}
+    for (int i = 0; i++; i <= MaxClients)
+    {
+        RemovePing(i);
+    }
 }
 
 public void Shavit_OnChatConfigLoaded()
 {
-	Shavit_GetChatStringsStruct(gS_ChatStrings);
+    Shavit_GetChatStringsStruct(gS_ChatStrings);
 }
 
 public Action Command_EnablePaint(int client, int args)
 {
-	gB_IsPainting[client] = true;
+    gB_IsPainting[client] = true;
 
-	return Plugin_Handled;
+    return Plugin_Handled;
 }
 
 public Action Command_DisablePaint(int client, int args)
 {
-	if(!gB_PaintMode[client])
-	{
-		gB_IsPainting[client] = false;		
-	}
+    if (!gB_PaintMode[client])
+    {
+        gB_IsPainting[client] = false;
+    }
 
-	return Plugin_Handled;
+    return Plugin_Handled;
 }
 
 public Action Command_Paint(int client, int args)
 {
-	OpenPaintMenu(client);
+    OpenPaintMenu(client);
 
-	return Plugin_Handled;
+    return Plugin_Handled;
 }
 
 public Action Command_PingMenu(int client, int args)
 {
-	OpenPingMenu(client);
+    OpenPingMenu(client);
 
-	return Plugin_Handled;
+    return Plugin_Handled;
 }
 
 public Action Command_Ping(int client, int args)
 {
-	if(!IsValidClient(client))
-	{
-		return Plugin_Handled;
-	}
+    if (!IsValidClient(client))
+    {
+        return Plugin_Handled;
+    }
 
-	if(GetGameTickCount() - gI_PlayerLastPing[client] <= gI_PingIntervalTick)
-	{
-		return Plugin_Handled;
-	}
+    if (GetGameTickCount() - gI_PlayerLastPing[client] <= gI_PingIntervalTick)
+    {
+        return Plugin_Handled;
+    }
 
-	RemovePing(client);
+    RemovePing(client);
 
-	float pos[3];
-	if(!TraceEye(client, pos))
-	{
-		return Plugin_Handled;
-	}
+    float pos[3];
+    if (!TraceEye(client, pos))
+    {
+        return Plugin_Handled;
+    }
 
-	float angle[3];
-	CaculatePlaneRotation(angle);
+    float angle[3];
+    CaculatePlaneRotation(angle);
 
-	float vec[3];
-	GetAngleVectors(angle, vec, NULL_VECTOR, NULL_VECTOR);
-	
-	pos[0] -= vec[0] * 1.0;
-	pos[1] -= vec[1] * 1.0;
-	pos[2] -= vec[2] * 1.0;
+    float vec[3];
+    GetAngleVectors(angle, vec, NULL_VECTOR, NULL_VECTOR);
 
-	int color[4];
-	GetPingColor(gI_PingColor[client], color);
+    pos[0] -= vec[0] * 1.0;
+    pos[1] -= vec[1] * 1.0;
+    pos[2] -= vec[2] * 1.0;
 
-	CreatePingEffect(client, pos, angle, color, gCV_PingDuration.FloatValue);
+    int color[4];
+    GetPingColor(gI_PingColor[client], color);
 
-	return Plugin_Handled;
+    CreatePingEffect(client, pos, angle, color, gCV_PingDuration.FloatValue);
+
+    return Plugin_Handled;
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
 {
-	if (cmdnum % 2 != 0)
-	{
-		return Plugin_Continue;
-	}
+    if (cmdnum % 2 != 0)
+    {
+        return Plugin_Continue;
+    }
 
     if (IsClientInGame(client) && gB_IsPainting[client])
     {
@@ -485,267 +490,267 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 void OpenPingMenu(int client)
 {
-	gI_LastOpenedMenu[client] = MENU_PING;
+    gI_LastOpenedMenu[client] = MENU_PING;
 
-	Menu menu = new Menu(Ping_MenuHandler);
+    Menu menu                 = new Menu(Ping_MenuHandler);
 
-	menu.SetTitle("%T\n  \n%T\n ", "PingMenuTitle", client, "PingTips", client);
+    menu.SetTitle("%T\n  \n%T\n ", "PingMenuTitle", client, "PingTips", client);
 
-	char sMenuItem[64];
+    char sMenuItem[64];
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "CreatePingMarker", client);
-	menu.AddItem("ping", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "CreatePingMarker", client);
+    menu.AddItem("ping", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "RemovePingMarker", client);
-	menu.AddItem("unping", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "RemovePingMarker", client);
+    menu.AddItem("unping", sMenuItem);
 
-	if(gI_Partner[client] == 0)
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintSelectPartner", client);
-		menu.AddItem("partner", sMenuItem);
-	}
-	else
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %N\n ", "RemovePartner", client, gI_Partner[client]);
-		menu.AddItem("remove", sMenuItem);
-	}
+    if (gI_Partner[client] == 0)
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintSelectPartner", client);
+        menu.AddItem("partner", sMenuItem);
+    }
+    else
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %N\n ", "RemovePartner", client, gI_Partner[client]);
+        menu.AddItem("remove", sMenuItem);
+    }
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n \n \n \n ", "PingOptions", client);
-	menu.AddItem("option", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n \n \n \n ", "PingOptions", client);
+    menu.AddItem("option", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "<< %T", "PaintMenuTitle", client);
-	menu.AddItem("paintmenu", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "<< %T", "PaintMenuTitle", client);
+    menu.AddItem("paintmenu", sMenuItem);
 
-	menu.Display(client, MENU_TIME_FOREVER);
+    menu.Display(client, MENU_TIME_FOREVER);
 }
 
 public int Ping_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[16];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[16];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		if(StrEqual(sInfo, "ping"))
-		{
-			Command_Ping(param1, 0);
-			OpenPingMenu(param1);
-		}
-		else if(StrEqual(sInfo, "unping"))
-		{
-			RemovePing(param1);
+        if (StrEqual(sInfo, "ping"))
+        {
+            Command_Ping(param1, 0);
+            OpenPingMenu(param1);
+        }
+        else if (StrEqual(sInfo, "unping"))
+        {
+            RemovePing(param1);
 
-			OpenPingMenu(param1);
-		}
-		else if(StrEqual(sInfo, "option"))
-		{
-			OpenPingOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "partner"))
-		{
-			OpenPartnerMenu(param1);
-		}
-		else if(StrEqual(sInfo, "remove"))
-		{
-			RemovePartner(param1);
+            OpenPingMenu(param1);
+        }
+        else if (StrEqual(sInfo, "option"))
+        {
+            OpenPingOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "partner"))
+        {
+            OpenPartnerMenu(param1);
+        }
+        else if (StrEqual(sInfo, "remove"))
+        {
+            RemovePartner(param1);
 
-			OpenPingMenu(param1);
-		}
-		else if(StrEqual(sInfo, "paintmenu"))
-		{
-			OpenPaintMenu(param1);
-		}
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+            OpenPingMenu(param1);
+        }
+        else if (StrEqual(sInfo, "paintmenu"))
+        {
+            OpenPaintMenu(param1);
+        }
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public void OpenPingOptionMenu(int client)
 {
-	Menu menu = new Menu(PingtOption_MenuHandler);
-	menu.SetTitle("%T\n ", "PingOptionMenuTitle", client);
+    Menu menu = new Menu(PingtOption_MenuHandler);
+    menu.SetTitle("%T\n ", "PingOptionMenuTitle", client);
 
-	char sMenuItem[64];
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T: ", "PingDuration", client);
+    char sMenuItem[64];
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T: ", "PingDuration", client);
 
-	if(gB_PingDuration[client])
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%s%T", sMenuItem, "DurationLong", client);
-	}
-	else
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%s%T", sMenuItem, "DurationShort", client, gCV_PingDuration.IntValue);
-	}
-	
-	menu.AddItem("duration", sMenuItem);
-
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PingColor", client, gS_PingColors[gI_PingColor[client]][0], client);
-	menu.AddItem("color", sMenuItem);
-
-	FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T", gB_PingSound[client] ? "ItemEnabled":"ItemDisabled", client, "PingSound", client);
-	menu.AddItem("sound", sMenuItem);
-
-	FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T", gB_ReciveRequest[client] ? "ItemEnabled":"ItemDisabled", client, "ReceivePartnerRequest", client);
-	menu.AddItem("receive", sMenuItem);
-
-	if(CheckClientAccess(client))
+    if (gB_PingDuration[client])
     {
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PingObject", client, gB_PingToAll[client] ? "ObjectAll":"ObjectSingle", client);
-		menu.AddItem("object", sMenuItem);
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%s%T", sMenuItem, "DurationLong", client);
+    }
+    else
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%s%T", sMenuItem, "DurationShort", client, gCV_PingDuration.IntValue);
     }
 
-	menu.ExitBackButton = true;
+    menu.AddItem("duration", sMenuItem);
 
-	menu.Display(client, MENU_TIME_FOREVER);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PingColor", client, gS_PingColors[gI_PingColor[client]][0], client);
+    menu.AddItem("color", sMenuItem);
+
+    FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T", gB_PingSound[client] ? "ItemEnabled" : "ItemDisabled", client, "PingSound", client);
+    menu.AddItem("sound", sMenuItem);
+
+    FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T", gB_ReciveRequest[client] ? "ItemEnabled" : "ItemDisabled", client, "ReceivePartnerRequest", client);
+    menu.AddItem("receive", sMenuItem);
+
+    if (CheckClientAccess(client))
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PingObject", client, gB_PingToAll[client] ? "ObjectAll" : "ObjectSingle", client);
+        menu.AddItem("object", sMenuItem);
+    }
+
+    menu.ExitBackButton = true;
+
+    menu.Display(client, MENU_TIME_FOREVER);
 }
 
 public int PingtOption_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[16];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[16];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		if(StrEqual(sInfo, "duration"))
-		{
-			gB_PingDuration[param1] = !gB_PingDuration[param1];
-			SetClientCookieBool(param1, gH_PlayerPingDuration, gB_PingDuration[param1]);
+        if (StrEqual(sInfo, "duration"))
+        {
+            gB_PingDuration[param1] = !gB_PingDuration[param1];
+            SetClientCookieBool(param1, gH_PlayerPingDuration, gB_PingDuration[param1]);
 
-			OpenPingOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "color"))
-		{
-			OpenPingColorMenu(param1);
-		}
-		else if(StrEqual(sInfo, "sound"))
-		{
-			gB_PingSound[param1] = !gB_PingSound[param1];
-			SetClientCookieBool(param1, gH_PlayerPingSound, gB_PingSound[param1]);
+            OpenPingOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "color"))
+        {
+            OpenPingColorMenu(param1);
+        }
+        else if (StrEqual(sInfo, "sound"))
+        {
+            gB_PingSound[param1] = !gB_PingSound[param1];
+            SetClientCookieBool(param1, gH_PlayerPingSound, gB_PingSound[param1]);
 
-			OpenPingOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "receive"))
-		{
-			gB_ReciveRequest[param1] = !gB_ReciveRequest[param1];
+            OpenPingOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "receive"))
+        {
+            gB_ReciveRequest[param1] = !gB_ReciveRequest[param1];
 
-			SetClientCookieBool(param1, gH_PlayerReciveRequest, gB_ReciveRequest[param1]);
-			OpenPingOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "object"))
-		{
-			gB_PingToAll[param1] = !gB_PingToAll[param1];
-			OpenPingOptionMenu(param1);
-		}
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		OpenPingMenu(param1);
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+            SetClientCookieBool(param1, gH_PlayerReciveRequest, gB_ReciveRequest[param1]);
+            OpenPingOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "object"))
+        {
+            gB_PingToAll[param1] = !gB_PingToAll[param1];
+            OpenPingOptionMenu(param1);
+        }
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        OpenPingMenu(param1);
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public Action Command_PingColor(int client, int args)
 {
-	OpenPingColorMenu(client);
+    OpenPingColorMenu(client);
 
-	return Plugin_Continue;
+    return Plugin_Continue;
 }
 
 void OpenPingColorMenu(int client, int item = 0)
 {
-	Menu menu = new Menu(PingColour_MenuHandler);
+    Menu menu = new Menu(PingColour_MenuHandler);
 
-	menu.SetTitle("%T\n ", "PingColorMenuTitle", client);
-	
-	char sMenuItem[64];
-	for (int i = 0; i < sizeof(gS_PingColors); i++)
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T", gS_PingColors[i][0], client);
+    menu.SetTitle("%T\n ", "PingColorMenuTitle", client);
 
-		menu.AddItem("", sMenuItem, gI_PingColor[client] == i ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
-	}
+    char sMenuItem[64];
+    for (int i = 0; i < sizeof(gS_PingColors); i++)
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T", gS_PingColors[i][0], client);
 
-	menu.ExitBackButton = true;
-	menu.DisplayAt(client, item, MENU_TIME_FOREVER);
+        menu.AddItem("", sMenuItem, gI_PingColor[client] == i ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
+    }
+
+    menu.ExitBackButton = true;
+    menu.DisplayAt(client, item, MENU_TIME_FOREVER);
 }
 
 public int PingColour_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		gI_PingColor[param1] = param2;
-		SetClientCookieInt(param1, gH_PlayerPingColor, gI_PingColor[param1]);
+    if (action == MenuAction_Select)
+    {
+        gI_PingColor[param1] = param2;
+        SetClientCookieInt(param1, gH_PlayerPingColor, gI_PingColor[param1]);
 
-		if(gI_PlayerPing[param1] > 0)
-		{
-			int color[4];
-			GetPingColor(param2, color);
-			SetEntityRenderColor(gI_PlayerPing[param1], color[0], color[1], color[2], color[3]);
-		}
+        if (gI_PlayerPing[param1] > 0)
+        {
+            int color[4];
+            GetPingColor(param2, color);
+            SetEntityRenderColor(gI_PlayerPing[param1], color[0], color[1], color[2], color[3]);
+        }
 
-		OpenPingColorMenu(param1, GetMenuSelectionPosition());
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		OpenPingOptionMenu(param1);
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+        OpenPingColorMenu(param1, GetMenuSelectionPosition());
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        OpenPingOptionMenu(param1);
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 void OpenPaintMenu(int client)
 {
-	gI_LastOpenedMenu[client] = MENU_PAINT;
+    gI_LastOpenedMenu[client] = MENU_PAINT;
 
-	Menu menu = new Menu(Paint_MenuHandler);
+    Menu menu                 = new Menu(Paint_MenuHandler);
 
-	menu.SetTitle("%T\n  \n%T\n ", "PaintMenuTitle", client, "PaintTips", client);
+    menu.SetTitle("%T\n  \n%T\n ", "PaintMenuTitle", client, "PaintTips", client);
 
-	char sMenuItem[64];
+    char sMenuItem[64];
 
-	if(gB_PaintMode[client])
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", gB_ErasePaint[client] ? "ToggleErase":"TogglePaint", client);
-		menu.AddItem("paint", sMenuItem);
-	}
-	else
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T\n ", gB_IsPainting[client] ? "ItemEnabled":"ItemDisabled", client, gB_ErasePaint[client] ? "ToggleErase":"TogglePaint", client);
-		menu.AddItem("paint", sMenuItem);		
-	}
+    if (gB_PaintMode[client])
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", gB_ErasePaint[client] ? "ToggleErase" : "TogglePaint", client);
+        menu.AddItem("paint", sMenuItem);
+    }
+    else
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T\n ", gB_IsPainting[client] ? "ItemEnabled" : "ItemDisabled", client, gB_ErasePaint[client] ? "ToggleErase" : "TogglePaint", client);
+        menu.AddItem("paint", sMenuItem);
+    }
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintEraser", client, gB_ErasePaint[client] ? "EraserOn":"EraserOff", client);
-	menu.AddItem("erase", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintEraser", client, gB_ErasePaint[client] ? "EraserOn" : "EraserOff", client);
+    menu.AddItem("erase", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintClear", client);
-	menu.AddItem("clear", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintClear", client);
+    menu.AddItem("clear", sMenuItem);
 
-	if(gI_Partner[client] == 0)
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintSelectPartner", client);
-		menu.AddItem("partner", sMenuItem);
-	}
-	else
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %N\n ", "RemovePartner", client, gI_Partner[client]);
-		menu.AddItem("remove", sMenuItem);
-	}
+    if (gI_Partner[client] == 0)
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintSelectPartner", client);
+        menu.AddItem("partner", sMenuItem);
+    }
+    else
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %N\n ", "RemovePartner", client, gI_Partner[client]);
+        menu.AddItem("remove", sMenuItem);
+    }
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n \n ", "PaintOptions", client);
-	menu.AddItem("option", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n \n ", "PaintOptions", client);
+    menu.AddItem("option", sMenuItem);
 
     FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "PaintSave", client);
     menu.AddItem("save", sMenuItem);
@@ -756,244 +761,244 @@ void OpenPaintMenu(int client)
     FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "PaintDelete", client);
     menu.AddItem("delete", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T >>", "PingMenuTitle", client);
-	menu.AddItem("pingmenu", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T >>", "PingMenuTitle", client);
+    menu.AddItem("pingmenu", sMenuItem);
 
-	menu.Display(client, MENU_TIME_FOREVER);
+    menu.Display(client, MENU_TIME_FOREVER);
 }
 
 public int Paint_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[16];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[16];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		if(StrEqual(sInfo, "paint"))
-		{
-			gB_IsPainting[param1] = !gB_IsPainting[param1];
-			OpenPaintMenu(param1);
-		}
-		else if(StrEqual(sInfo, "option"))
-		{
-			OpenPaintOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "erase"))
-		{
-			gB_ErasePaint[param1] = !gB_ErasePaint[param1];
-			OpenPaintMenu(param1);
-		}
-		else if(StrEqual(sInfo, "clear"))
+        if (StrEqual(sInfo, "paint"))
+        {
+            gB_IsPainting[param1] = !gB_IsPainting[param1];
+            OpenPaintMenu(param1);
+        }
+        else if (StrEqual(sInfo, "option"))
+        {
+            OpenPaintOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "erase"))
+        {
+            gB_ErasePaint[param1] = !gB_ErasePaint[param1];
+            OpenPaintMenu(param1);
+        }
+        else if (StrEqual(sInfo, "clear"))
         {
             OpenConfirmMenu(param1, 0);
         }
-		else if(StrEqual(sInfo, "partner"))
-		{
-			OpenPartnerMenu(param1);
-		}
-		else if(StrEqual(sInfo, "remove"))
-		{
-			RemovePartner(param1);
+        else if (StrEqual(sInfo, "partner"))
+        {
+            OpenPartnerMenu(param1);
+        }
+        else if (StrEqual(sInfo, "remove"))
+        {
+            RemovePartner(param1);
 
-			OpenPaintMenu(param1);
-		}
-        else if(StrEqual(sInfo, "save"))
+            OpenPaintMenu(param1);
+        }
+        else if (StrEqual(sInfo, "save"))
         {
             Command_PaintSave(param1, 0);
             OpenPaintMenu(param1);
         }
-        else if(StrEqual(sInfo, "load"))
+        else if (StrEqual(sInfo, "load"))
         {
             Command_PaintLoad(param1, 0);
             OpenPaintMenu(param1);
         }
-        else if(StrEqual(sInfo, "delete"))
+        else if (StrEqual(sInfo, "delete"))
         {
             OpenConfirmMenu(param1, 1);
         }
-		else if(StrEqual(sInfo, "pingmenu"))
-		{
-			OpenPingMenu(param1);
-		}
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+        else if (StrEqual(sInfo, "pingmenu"))
+        {
+            OpenPingMenu(param1);
+        }
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 void OpenPaintOptionMenu(int client)
 {
-	Menu menu = new Menu(PaintOption_MenuHandler);
-	menu.SetTitle("%T\n ", "PaintOptionMenuTitle", client);
+    Menu menu = new Menu(PaintOption_MenuHandler);
+    menu.SetTitle("%T\n ", "PaintOptionMenuTitle", client);
 
-	char sMenuItem[64];
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintMode", client, gB_PaintMode[client] ? "ModeSingle":"ModeContinuous", client);
-	menu.AddItem("mode", sMenuItem);
+    char sMenuItem[64];
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintMode", client, gB_PaintMode[client] ? "ModeSingle" : "ModeContinuous", client);
+    menu.AddItem("mode", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintColor", client, gS_PaintColors[gI_PlayerPaintColor[client]][0], client);
-	menu.AddItem("color", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintColor", client, gS_PaintColors[gI_PlayerPaintColor[client]][0], client);
+    menu.AddItem("color", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintSize", client, gS_PaintSizes[gI_PlayerPaintSize[client]][0], client);
-	menu.AddItem("size", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintSize", client, gS_PaintSizes[gI_PlayerPaintSize[client]][0], client);
+    menu.AddItem("size", sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T", gB_ReciveRequest[client] ? "ItemEnabled":"ItemDisabled", client, "ReceivePartnerRequest", client);
-	menu.AddItem("receive", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "[%T] %T", gB_ReciveRequest[client] ? "ItemEnabled" : "ItemDisabled", client, "ReceivePartnerRequest", client);
+    menu.AddItem("receive", sMenuItem);
 
-	if(CheckClientAccess(client))
+    if (CheckClientAccess(client))
     {
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintObject", client, gB_PaintToAll[client] ? "ObjectAll":"ObjectSingle", client);
-		menu.AddItem("object", sMenuItem);
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T: %T", "PaintObject", client, gB_PaintToAll[client] ? "ObjectAll" : "ObjectSingle", client);
+        menu.AddItem("object", sMenuItem);
     }
 
-	menu.ExitBackButton = true;
+    menu.ExitBackButton = true;
 
-	menu.Display(client, MENU_TIME_FOREVER);
+    menu.Display(client, MENU_TIME_FOREVER);
 }
 
 public int PaintOption_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[16];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[16];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		if(StrEqual(sInfo, "color"))
-		{
-			OpenPaintColorMenu(param1);
-		}
-		else if(StrEqual(sInfo, "size"))
-		{
-			OpenPaintSizeMenu(param1);
-		}
-		else if(StrEqual(sInfo, "mode"))
-		{
-			if(gB_IsPainting[param1])
-			{
-				Shavit_PrintToChat(param1, "%T", "PaintModeChangeError", param1);
-			}
-			else
-			{
-				gB_PaintMode[param1] = !gB_PaintMode[param1];
-				SetClientCookieBool(param1, gH_PlayerPaintMode, gB_PaintMode[param1]);
-			}
+        if (StrEqual(sInfo, "color"))
+        {
+            OpenPaintColorMenu(param1);
+        }
+        else if (StrEqual(sInfo, "size"))
+        {
+            OpenPaintSizeMenu(param1);
+        }
+        else if (StrEqual(sInfo, "mode"))
+        {
+            if (gB_IsPainting[param1])
+            {
+                Shavit_PrintToChat(param1, "%T", "PaintModeChangeError", param1);
+            }
+            else
+            {
+                gB_PaintMode[param1] = !gB_PaintMode[param1];
+                SetClientCookieBool(param1, gH_PlayerPaintMode, gB_PaintMode[param1]);
+            }
 
-			OpenPaintOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "object"))
-		{
-			gB_PaintToAll[param1] = !gB_PaintToAll[param1];
+            OpenPaintOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "object"))
+        {
+            gB_PaintToAll[param1] = !gB_PaintToAll[param1];
 
-			OpenPaintOptionMenu(param1);
-		}
-		else if(StrEqual(sInfo, "receive"))
-		{
-			gB_ReciveRequest[param1] = !gB_ReciveRequest[param1];
-			SetClientCookieBool(param1, gH_PlayerReciveRequest, gB_ReciveRequest[param1]);
+            OpenPaintOptionMenu(param1);
+        }
+        else if (StrEqual(sInfo, "receive"))
+        {
+            gB_ReciveRequest[param1] = !gB_ReciveRequest[param1];
+            SetClientCookieBool(param1, gH_PlayerReciveRequest, gB_ReciveRequest[param1]);
 
-			OpenPaintOptionMenu(param1);
-		}
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		OpenPaintMenu(param1);
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+            OpenPaintOptionMenu(param1);
+        }
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        OpenPaintMenu(param1);
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public Action Command_PaintColour(int client, int args)
 {
-	OpenPaintColorMenu(client);
+    OpenPaintColorMenu(client);
 
-	return Plugin_Continue;
+    return Plugin_Continue;
 }
 
 void OpenPaintColorMenu(int client, int item = 0)
 {
-	Menu menu = new Menu(PaintColour_MenuHandler);
+    Menu menu = new Menu(PaintColour_MenuHandler);
 
-	menu.SetTitle("%T\n ", "PaintColorMenuTitle", client);
-	
-	char sMenuItem[64];
-	for (int i = 0; i < sizeof(gS_PaintColors); i++)
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T", gS_PaintColors[i][0], client);
+    menu.SetTitle("%T\n ", "PaintColorMenuTitle", client);
 
-		menu.AddItem("", sMenuItem, gI_PlayerPaintColor[client] == i ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
-	}
+    char sMenuItem[64];
+    for (int i = 0; i < sizeof(gS_PaintColors); i++)
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T", gS_PaintColors[i][0], client);
 
-	menu.ExitBackButton = true;
-	menu.DisplayAt(client, item, MENU_TIME_FOREVER);
+        menu.AddItem("", sMenuItem, gI_PlayerPaintColor[client] == i ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
+    }
+
+    menu.ExitBackButton = true;
+    menu.DisplayAt(client, item, MENU_TIME_FOREVER);
 }
 
 public int PaintColour_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		gI_PlayerPaintColor[param1] = param2;
-		SetClientCookieInt(param1, gH_PlayerPaintColor, gI_PlayerPaintColor[param1]);
+    if (action == MenuAction_Select)
+    {
+        gI_PlayerPaintColor[param1] = param2;
+        SetClientCookieInt(param1, gH_PlayerPaintColor, gI_PlayerPaintColor[param1]);
 
-		OpenPaintColorMenu(param1, GetMenuSelectionPosition());
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		OpenPaintOptionMenu(param1);
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+        OpenPaintColorMenu(param1, GetMenuSelectionPosition());
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        OpenPaintOptionMenu(param1);
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public void RemovePartner(int client)
 {
-	if(gI_Partner[client] != 0)
-	{
-		int partner = gI_Partner[client];
+    if (gI_Partner[client] != 0)
+    {
+        int partner         = gI_Partner[client];
 
-		gI_Partner[client] = 0; 
-		gI_Partner[partner] = 0;
+        gI_Partner[client]  = 0;
+        gI_Partner[partner] = 0;
 
-		char sName[64];
-		GetClientName(client, sName, sizeof(sName));
-		char sPartnerName[64];
-		GetClientName(partner, sPartnerName, sizeof(sPartnerName));
+        char sName[64];
+        GetClientName(client, sName, sizeof(sName));
+        char sPartnerName[64];
+        GetClientName(partner, sPartnerName, sizeof(sPartnerName));
 
-		Shavit_PrintToChat(client, "%T", "Unpartnered", client, gS_ChatStrings.sVariable2, sPartnerName, gS_ChatStrings.sText);
-		Shavit_PrintToChat(partner, "%T", "Unpartnered", partner, gS_ChatStrings.sVariable2, sName, gS_ChatStrings.sText);				
-	}
-	else
-	{
-		Shavit_PrintToChat(client, "%T", "NoPartner", client);
-	}
+        Shavit_PrintToChat(client, "%T", "Unpartnered", client, gS_ChatStrings.sVariable2, sPartnerName, gS_ChatStrings.sText);
+        Shavit_PrintToChat(partner, "%T", "Unpartnered", partner, gS_ChatStrings.sVariable2, sName, gS_ChatStrings.sText);
+    }
+    else
+    {
+        Shavit_PrintToChat(client, "%T", "NoPartner", client);
+    }
 }
 
 public void OnClientDisconnect(int client)
 {
-	if(gI_Partnering[client] != 0)
-	{
-		PartneringResponse(client, gI_Partnering[client], 4);
-	}
+    if (gI_Partnering[client] != 0)
+    {
+        PartneringResponse(client, gI_Partnering[client], 4);
+    }
 
-	if(gI_Partner[client] != 0)
-	{
-		char sName[64];
-		GetClientName(client, sName, sizeof(sName));
-		Shavit_PrintToChat(gI_Partner[client], "%T", "PartnerDisconnected", gI_Partner[client], gS_ChatStrings.sVariable2, sName, gS_ChatStrings.sText);
-		gI_Partner[gI_Partner[client]] = 0;
-		gI_Partner[client] = 0;
-	}
+    if (gI_Partner[client] != 0)
+    {
+        char sName[64];
+        GetClientName(client, sName, sizeof(sName));
+        Shavit_PrintToChat(gI_Partner[client], "%T", "PartnerDisconnected", gI_Partner[client], gS_ChatStrings.sVariable2, sName, gS_ChatStrings.sText);
+        gI_Partner[gI_Partner[client]] = 0;
+        gI_Partner[client]             = 0;
+    }
 
-	RemovePing(client);
+    RemovePing(client);
 
     delete g_hPaintData[client];
     delete g_hPendingPaints[client];
@@ -1001,431 +1006,431 @@ public void OnClientDisconnect(int client)
 
 public void OpenPartnerMenu(int client)
 {
-	Menu menu = new Menu(Partner_MenuHandler);
-	menu.SetTitle("%T\n ", "SendPartnerRequest", client);
+    Menu menu = new Menu(Partner_MenuHandler);
+    menu.SetTitle("%T\n ", "SendPartnerRequest", client);
 
-	char sMenuItem[64];
-	char sInfo[8];
+    char sMenuItem[64];
+    char sInfo[8];
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "Refresh", client);
-	menu.AddItem("refresh", sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T\n ", "Refresh", client);
+    menu.AddItem("refresh", sMenuItem);
 
-	for (int i = 1; i <= MaxClients; i++)
-	{
-		if (IsClientInGame(i) && !IsFakeClient(i) && i != client && gB_ReciveRequest[i] && gI_Partner[i] == 0 && gI_Partnering[i] == 0)
-		{
-			IntToString(i, sInfo, sizeof(sInfo));
-			FormatEx(sMenuItem, sizeof(sMenuItem), "%N", i);
-			menu.AddItem(sInfo, sMenuItem);
-		}
-	}
+    for (int i = 1; i <= MaxClients; i++)
+    {
+        if (IsClientInGame(i) && !IsFakeClient(i) && i != client && gB_ReciveRequest[i] && gI_Partner[i] == 0 && gI_Partnering[i] == 0)
+        {
+            IntToString(i, sInfo, sizeof(sInfo));
+            FormatEx(sMenuItem, sizeof(sMenuItem), "%N", i);
+            menu.AddItem(sInfo, sMenuItem);
+        }
+    }
 
-	if(menu.ItemCount == 1)
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "NoPartnerFound", client);
-		menu.AddItem("", sMenuItem, ITEMDRAW_DISABLED);
-	}
+    if (menu.ItemCount == 1)
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "NoPartnerFound", client);
+        menu.AddItem("", sMenuItem, ITEMDRAW_DISABLED);
+    }
 
-	menu.ExitBackButton = true;
-	menu.Display(client, MENU_TIME_FOREVER);
+    menu.ExitBackButton = true;
+    menu.Display(client, MENU_TIME_FOREVER);
 }
 
 public int Partner_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[8];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[8];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		if(StrEqual(sInfo, "refresh"))
-		{
-			OpenPartnerMenu(param1);
-		}
-		else
-		{
-			int partner = StringToInt(sInfo);
+        if (StrEqual(sInfo, "refresh"))
+        {
+            OpenPartnerMenu(param1);
+        }
+        else
+        {
+            int partner = StringToInt(sInfo);
 
-			SendPartnerRequest(param1, partner);
-			Shavit_PrintToChat(param1, "%T", "RequestSent", param1);			
-		}
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		if(gI_LastOpenedMenu[param1] == MENU_PAINT)
-		{
-			OpenPaintMenu(param1);
-		}
-		else if(gI_LastOpenedMenu[param1] == MENU_PING)
-		{
-			OpenPingMenu(param1);
-		}
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+            SendPartnerRequest(param1, partner);
+            Shavit_PrintToChat(param1, "%T", "RequestSent", param1);
+        }
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        if (gI_LastOpenedMenu[param1] == MENU_PAINT)
+        {
+            OpenPaintMenu(param1);
+        }
+        else if (gI_LastOpenedMenu[param1] == MENU_PING)
+        {
+            OpenPingMenu(param1);
+        }
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public void SendPartnerRequest(int client, int partner)
 {
-	gI_Partnering[client] = partner;
-	gI_Partnering[partner] = client;
+    gI_Partnering[client]  = partner;
+    gI_Partnering[partner] = client;
 
-	char sName[64];
-	GetClientName(client, sName, sizeof(sName));
-	char sPartnerName[64];
-	GetClientName(partner, sPartnerName, sizeof(sPartnerName));
+    char sName[64];
+    GetClientName(client, sName, sizeof(sName));
+    char sPartnerName[64];
+    GetClientName(partner, sPartnerName, sizeof(sPartnerName));
 
-	char sMenuItem[64];
-	char sInfo[8];
-	Menu waitingResponseMenu = new Menu(PartnerWaitingResponse_MenuHandler);
-	waitingResponseMenu.SetTitle("%T\n ", "ResponseWaitingMenuTitle", client, sPartnerName);
+    char sMenuItem[64];
+    char sInfo[8];
+    Menu waitingResponseMenu = new Menu(PartnerWaitingResponse_MenuHandler);
+    waitingResponseMenu.SetTitle("%T\n ", "ResponseWaitingMenuTitle", client, sPartnerName);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "CancelRequest", client);
-	IntToString(partner, sInfo, sizeof(sInfo));
-	waitingResponseMenu.AddItem(sInfo, sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "CancelRequest", client);
+    IntToString(partner, sInfo, sizeof(sInfo));
+    waitingResponseMenu.AddItem(sInfo, sMenuItem);
 
-	waitingResponseMenu.ExitButton = false;
-	waitingResponseMenu.Display(client, MENU_TIME_FOREVER);
+    waitingResponseMenu.ExitButton = false;
+    waitingResponseMenu.Display(client, MENU_TIME_FOREVER);
 
-	Menu requestMenu = new Menu(PartnerRequest_MenuHandler);
-	requestMenu.SetTitle("%T\n ", "ReceivedRequest", partner, sName);
+    Menu requestMenu = new Menu(PartnerRequest_MenuHandler);
+    requestMenu.SetTitle("%T\n ", "ReceivedRequest", partner, sName);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "AcceptRequest", partner);
-	FormatEx(sInfo, sizeof(sInfo), "a;%d", client);
-	requestMenu.AddItem(sInfo, sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "AcceptRequest", partner);
+    FormatEx(sInfo, sizeof(sInfo), "a;%d", client);
+    requestMenu.AddItem(sInfo, sMenuItem);
 
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "DeclineRequest", partner);
-	FormatEx(sInfo, sizeof(sInfo), "d;%d", client);
-	requestMenu.AddItem(sInfo, sMenuItem);
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "DeclineRequest", partner);
+    FormatEx(sInfo, sizeof(sInfo), "d;%d", client);
+    requestMenu.AddItem(sInfo, sMenuItem);
 
-	requestMenu.ExitButton = false;
-	requestMenu.Display(partner, MENU_TIME_FOREVER);
+    requestMenu.ExitButton = false;
+    requestMenu.Display(partner, MENU_TIME_FOREVER);
 }
 
 public int PartnerWaitingResponse_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[8];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[8];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		int partner = StringToInt(sInfo);
+        int partner = StringToInt(sInfo);
 
-		PartneringResponse(param1, partner, RESPONSE_CANCEL);
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		char sInfo[8];
-		menu.GetItem(0, sInfo, sizeof(sInfo));
-		int partner = StringToInt(sInfo);
+        PartneringResponse(param1, partner, RESPONSE_CANCEL);
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        char sInfo[8];
+        menu.GetItem(0, sInfo, sizeof(sInfo));
+        int partner = StringToInt(sInfo);
 
-		PartneringResponse(param1, partner, RESPONSE_CANCEL);
-	}
+        PartneringResponse(param1, partner, RESPONSE_CANCEL);
+    }
 
-	return 0;
+    return 0;
 }
 
 public int PartnerRequest_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		char sInfo[16];
-		menu.GetItem(param2, sInfo, sizeof(sInfo));
+    if (action == MenuAction_Select)
+    {
+        char sInfo[16];
+        menu.GetItem(param2, sInfo, sizeof(sInfo));
 
-		char sExploded[2][8];
-		ExplodeString(sInfo, ";", sExploded, 2, 8);
+        char sExploded[2][8];
+        ExplodeString(sInfo, ";", sExploded, 2, 8);
 
-		int partner = StringToInt(sExploded[1]);
+        int partner = StringToInt(sExploded[1]);
 
-		if(StrEqual(sExploded[0], "a"))
-		{
-			PartneringResponse(param1, partner, RESPONSE_ACCEPT);
-		}
-		else if(StrEqual(sExploded[0], "d"))
-		{
-			PartneringResponse(param1, partner, RESPONSE_DECLINE);
-		}
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		char sInfo[16];
-		menu.GetItem(0, sInfo, sizeof(sInfo));
+        if (StrEqual(sExploded[0], "a"))
+        {
+            PartneringResponse(param1, partner, RESPONSE_ACCEPT);
+        }
+        else if (StrEqual(sExploded[0], "d"))
+        {
+            PartneringResponse(param1, partner, RESPONSE_DECLINE);
+        }
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        char sInfo[16];
+        menu.GetItem(0, sInfo, sizeof(sInfo));
 
-		char sExploded[2][8];
-		ExplodeString(sInfo, ";", sExploded, 2, 8);
+        char sExploded[2][8];
+        ExplodeString(sInfo, ";", sExploded, 2, 8);
 
-		int partner = StringToInt(sExploded[1]);
+        int partner = StringToInt(sExploded[1]);
 
-		PartneringResponse(param1, partner, RESPONSE_DECLINE);
-	}
+        PartneringResponse(param1, partner, RESPONSE_DECLINE);
+    }
 
-	return 0;
+    return 0;
 }
 
 public void PartneringResponse(int client, int partner, int status)
 {
-	Menu menu = new Menu(PartnerResponse_MenuHandler);
-	menu.ExitBackButton = false;
-	menu.ExitButton = false;
+    Menu menu           = new Menu(PartnerResponse_MenuHandler);
+    menu.ExitBackButton = false;
+    menu.ExitButton     = false;
 
-	char sName[64];
-	GetClientName(client, sName, sizeof(sName));
-	char sPartnerName[64];
-	GetClientName(partner, sPartnerName, sizeof(sPartnerName));
+    char sName[64];
+    GetClientName(client, sName, sizeof(sName));
+    char sPartnerName[64];
+    GetClientName(partner, sPartnerName, sizeof(sPartnerName));
 
-	if(status == RESPONSE_ACCEPT) // accept
-	{
-		menu.SetTitle("%T\n%T\n ", "RequestAccepted", partner, sName, "MenuAutoClose", partner);
+    if (status == RESPONSE_ACCEPT)    // accept
+    {
+        menu.SetTitle("%T\n%T\n ", "RequestAccepted", partner, sName, "MenuAutoClose", partner);
 
-		gI_Partner[client] = partner;
-		gI_Partner[partner] = client;
+        gI_Partner[client]  = partner;
+        gI_Partner[partner] = client;
 
-		Shavit_PrintToChat(client, "%T", "Partnered", client, gS_ChatStrings.sVariable2, sPartnerName, gS_ChatStrings.sText);
-		Shavit_PrintToChat(partner, "%T", "Partnered", partner, gS_ChatStrings.sVariable2, sName, gS_ChatStrings.sText);
-	}
-	else 
-	{
-		if(status == RESPONSE_DECLINE) // decline
-		{
-			menu.SetTitle("%T\n%T\n ", "RequestDeclined", partner, sName, "MenuAutoClose", partner);
-		}
-		else if(status == RESPONSE_CANCEL) // cancel
-		{
-			menu.SetTitle("%T\n%T\n ", "RequestCanceled", partner, sName, "MenuAutoClose", partner);
-		}
-		else
-		{
-		menu.SetTitle("%T\n%T\n ", "RequestAborted", partner, sName, "MenuAutoClose", partner);			
-		}
-	}
+        Shavit_PrintToChat(client, "%T", "Partnered", client, gS_ChatStrings.sVariable2, sPartnerName, gS_ChatStrings.sText);
+        Shavit_PrintToChat(partner, "%T", "Partnered", partner, gS_ChatStrings.sVariable2, sName, gS_ChatStrings.sText);
+    }
+    else
+    {
+        if (status == RESPONSE_DECLINE)    // decline
+        {
+            menu.SetTitle("%T\n%T\n ", "RequestDeclined", partner, sName, "MenuAutoClose", partner);
+        }
+        else if (status == RESPONSE_CANCEL)    // cancel
+        {
+            menu.SetTitle("%T\n%T\n ", "RequestCanceled", partner, sName, "MenuAutoClose", partner);
+        }
+        else
+        {
+            menu.SetTitle("%T\n%T\n ", "RequestAborted", partner, sName, "MenuAutoClose", partner);
+        }
+    }
 
-	char sMenuItem[64];
-	FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "MenuClose", partner);
-	menu.AddItem("close", sMenuItem);
+    char sMenuItem[64];
+    FormatEx(sMenuItem, sizeof(sMenuItem), "%T", "MenuClose", partner);
+    menu.AddItem("close", sMenuItem);
 
-	menu.Display(partner, 10);
+    menu.Display(partner, 10);
 
-	gI_Partnering[client] = 0;
-	gI_Partnering[partner] = 0;
+    gI_Partnering[client]  = 0;
+    gI_Partnering[partner] = 0;
 }
 
 public int PartnerResponse_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		// nothing here
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+    if (action == MenuAction_Select)
+    {
+        // nothing here
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public Action Command_PaintSize(int client, int args)
 {
-	OpenPaintSizeMenu(client);
+    OpenPaintSizeMenu(client);
 
-	return Plugin_Continue;
+    return Plugin_Continue;
 }
 
 public Action Command_PaintMode(int client, int args)
 {
-	if(gB_IsPainting[client])
-	{
-		Shavit_PrintToChat(client, "%T", "PaintModeChangeError", client);
-	}
-	else
-	{
-		gB_PaintMode[client] = !gB_PaintMode[client];
+    if (gB_IsPainting[client])
+    {
+        Shavit_PrintToChat(client, "%T", "PaintModeChangeError", client);
+    }
+    else
+    {
+        gB_PaintMode[client] = !gB_PaintMode[client];
 
-		char sValue[8];
-		IntToString(view_as<int>(gB_PaintMode[client]), sValue, sizeof(sValue));
-		gH_PlayerPaintMode.Set(client, sValue);
+        char sValue[8];
+        IntToString(view_as<int>(gB_PaintMode[client]), sValue, sizeof(sValue));
+        gH_PlayerPaintMode.Set(client, sValue);
 
-		Shavit_PrintToChat(client, "%T: %T", "PaintMode", client, gB_PaintMode[client] ? "ModeSingle":"ModeContinuous", client);
-	}
+        Shavit_PrintToChat(client, "%T: %T", "PaintMode", client, gB_PaintMode[client] ? "ModeSingle" : "ModeContinuous", client);
+    }
 
-	return Plugin_Continue;
+    return Plugin_Continue;
 }
 
 public Action Command_PaintErase(int client, int args)
 {
-	gB_ErasePaint[client] = !gB_ErasePaint[client];
-	Shavit_PrintToChat(client, "%T: %T", "PaintEraser", client, gB_ErasePaint[client] ? "EraserOn":"EraserOff", client);
+    gB_ErasePaint[client] = !gB_ErasePaint[client];
+    Shavit_PrintToChat(client, "%T: %T", "PaintEraser", client, gB_ErasePaint[client] ? "EraserOn" : "EraserOff", client);
 
-	return Plugin_Continue;
+    return Plugin_Continue;
 }
 
 void OpenPaintSizeMenu(int client, int item = 0)
 {
-	Menu menu = new Menu(PaintSize_MenuHandler);
+    Menu menu = new Menu(PaintSize_MenuHandler);
 
-	menu.SetTitle("%T\n ", "PaintSizeMenuTitle", client);
+    menu.SetTitle("%T\n ", "PaintSizeMenuTitle", client);
 
-	char sMenuItem[64];
-	for (int i = 0; i < sizeof(gS_PaintSizes); i++)
-	{
-		FormatEx(sMenuItem, sizeof(sMenuItem), "%T", gS_PaintSizes[i][0], client);
-		menu.AddItem("", sMenuItem, gI_PlayerPaintSize[client] == i ? ITEMDRAW_DISABLED:ITEMDRAW_DEFAULT);
-	}
+    char sMenuItem[64];
+    for (int i = 0; i < sizeof(gS_PaintSizes); i++)
+    {
+        FormatEx(sMenuItem, sizeof(sMenuItem), "%T", gS_PaintSizes[i][0], client);
+        menu.AddItem("", sMenuItem, gI_PlayerPaintSize[client] == i ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
+    }
 
-	menu.ExitBackButton = true;
-	menu.DisplayAt(client, item, MENU_TIME_FOREVER);
+    menu.ExitBackButton = true;
+    menu.DisplayAt(client, item, MENU_TIME_FOREVER);
 }
 
 public int PaintSize_MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if(action == MenuAction_Select)
-	{
-		gI_PlayerPaintSize[param1] = param2;
-		SetClientCookieInt(param1, gH_PlayerPaintSize, gI_PlayerPaintSize[param1]);
+    if (action == MenuAction_Select)
+    {
+        gI_PlayerPaintSize[param1] = param2;
+        SetClientCookieInt(param1, gH_PlayerPaintSize, gI_PlayerPaintSize[param1]);
 
-		OpenPaintSizeMenu(param1, GetMenuSelectionPosition());
-	}
-	else if(action == MenuAction_Cancel)
-	{
-		OpenPaintOptionMenu(param1);
-	}
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
+        OpenPaintSizeMenu(param1, GetMenuSelectionPosition());
+    }
+    else if (action == MenuAction_Cancel)
+    {
+        OpenPaintOptionMenu(param1);
+    }
+    else if (action == MenuAction_End)
+    {
+        delete menu;
+    }
 
-	return 0;
+    return 0;
 }
 
 public int CreatePingEffect(int client, float pos[3], float rotation[3], int color[4], float duration)
 {
-	int iEntity = CreateEntityByName("prop_dynamic_override");
+    int iEntity            = CreateEntityByName("prop_dynamic_override");
 
-	gI_PlayerPing[client] = iEntity;
-	gI_PingEntity[iEntity] = client;
+    gI_PlayerPing[client]  = iEntity;
+    gI_PingEntity[iEntity] = client;
 
-	SetEntityModel(iEntity, PING_MODEL_PATH);
-	DispatchSpawn(iEntity);
-	ActivateEntity(iEntity);
-	SetEntPropVector(iEntity, Prop_Data, "m_angRotation", rotation);
-	SetEntityRenderMode(iEntity, RENDER_TRANSALPHA);
-	SetEntityRenderColor(iEntity, color[0], color[1], color[2], color[3]);
-	SDKHook(iEntity, SDKHook_SetTransmit, Hook_SetPingTransmit);
-	TeleportEntity(iEntity, pos, NULL_VECTOR, NULL_VECTOR);
+    SetEntityModel(iEntity, PING_MODEL_PATH);
+    DispatchSpawn(iEntity);
+    ActivateEntity(iEntity);
+    SetEntPropVector(iEntity, Prop_Data, "m_angRotation", rotation);
+    SetEntityRenderMode(iEntity, RENDER_TRANSALPHA);
+    SetEntityRenderColor(iEntity, color[0], color[1], color[2], color[3]);
+    SDKHook(iEntity, SDKHook_SetTransmit, Hook_SetPingTransmit);
+    TeleportEntity(iEntity, pos, NULL_VECTOR, NULL_VECTOR);
 
-	if(gB_PingSound[client])
-	{
-		EmitSoundToClient(client, PING_SOUND_PATH);		
-	}
+    if (gB_PingSound[client])
+    {
+        EmitSoundToClient(client, PING_SOUND_PATH);
+    }
 
-	if(gI_Partner[client] > 0 && gB_PingSound[gI_Partner[client]])
-	{
-		EmitSoundToClient(gI_Partner[client], PING_SOUND_PATH);	
-	}
+    if (gI_Partner[client] > 0 && gB_PingSound[gI_Partner[client]])
+    {
+        EmitSoundToClient(gI_Partner[client], PING_SOUND_PATH);
+    }
 
-	gI_PlayerLastPing[client] = GetGameTickCount();
+    gI_PlayerLastPing[client] = GetGameTickCount();
 
-	if(!gB_PingDuration[client])
-	{
-		gH_PingTimer[client] = CreateTimer(duration, Timer_RemovePingEffect, iEntity, TIMER_FLAG_NO_MAPCHANGE);		
-	}
+    if (!gB_PingDuration[client])
+    {
+        gH_PingTimer[client] = CreateTimer(duration, Timer_RemovePingEffect, iEntity, TIMER_FLAG_NO_MAPCHANGE);
+    }
 
-	return iEntity;
+    return iEntity;
 }
 
 public Action Hook_SetPingTransmit(int entity, int other)
 {
-	int target = other;
-	int owner = gI_PingEntity[entity];
+    int target = other;
+    int owner  = gI_PingEntity[entity];
 
-	if(IsClientObserver(other))
-	{
-		int iObserverMode = GetEntProp(other, Prop_Send, "m_iObserverMode");
+    if (IsClientObserver(other))
+    {
+        int iObserverMode = GetEntProp(other, Prop_Send, "m_iObserverMode");
 
-		if (iObserverMode >= 3 && iObserverMode <= 7)
-		{
-			int iTarget = GetEntPropEnt(other, Prop_Send, "m_hObserverTarget");
+        if (iObserverMode >= 3 && iObserverMode <= 7)
+        {
+            int iTarget = GetEntPropEnt(other, Prop_Send, "m_hObserverTarget");
 
-			if (IsValidEntity(target))
-			{
-				target = iTarget;
-			}
-		}
-	}
+            if (IsValidEntity(target))
+            {
+                target = iTarget;
+            }
+        }
+    }
 
-	if(owner > 0 && gB_PingToAll[owner])
-	{
-		return Plugin_Continue;
-	}
+    if (owner > 0 && gB_PingToAll[owner])
+    {
+        return Plugin_Continue;
+    }
 
-	if(target == owner || target == gI_Partner[owner])
-	{
-		return Plugin_Continue;
-	}
+    if (target == owner || target == gI_Partner[owner])
+    {
+        return Plugin_Continue;
+    }
 
-	return Plugin_Handled;
+    return Plugin_Handled;
 }
 
 public Action Timer_RemovePingEffect(Handle timer, int entity)
 {
-	int client = gI_PingEntity[entity];
+    int client           = gI_PingEntity[entity];
 
-	gH_PingTimer[client] = null;
+    gH_PingTimer[client] = null;
 
-	if(client == -1 || gI_PlayerPing[client] != entity)
-	{
-		return Plugin_Stop;
-	}
+    if (client == -1 || gI_PlayerPing[client] != entity)
+    {
+        return Plugin_Stop;
+    }
 
-	RemovePingEntity(entity);	
+    RemovePingEntity(entity);
 
-	return Plugin_Stop;
+    return Plugin_Stop;
 }
 
 public void RemovePing(int client)
 {
-	if(gI_PlayerPing[client] > 0)	
-	{
-		RemovePingEntity(gI_PlayerPing[client]);
-	}
+    if (gI_PlayerPing[client] > 0)
+    {
+        RemovePingEntity(gI_PlayerPing[client]);
+    }
 
-	if(gH_PingTimer[client] != null)
-	{
-		RemovePingTimer(client);
-	}
+    if (gH_PingTimer[client] != null)
+    {
+        RemovePingTimer(client);
+    }
 }
 
 public void RemovePingEntity(int entity)
 {
-	AcceptEntityInput(entity, "Kill");
-	gI_PlayerPing[gI_PingEntity[entity]] = 0;
-	gI_PingEntity[entity] = -1;
+    AcceptEntityInput(entity, "Kill");
+    gI_PlayerPing[gI_PingEntity[entity]] = 0;
+    gI_PingEntity[entity]                = -1;
 }
 
 public void RemovePingTimer(int client)
 {
-	if(gH_PingTimer[client] != null)
-	{
-		delete gH_PingTimer[client];
-	}
+    if (gH_PingTimer[client] != null)
+    {
+        delete gH_PingTimer[client];
+    }
 
-	delete gH_PingTimer[client];
+    delete gH_PingTimer[client];
 }
 
 void AddPaint(int client, float pos[3], int paint = 0, int size = 0)
 {
-	if(paint == 0)
-	{
-		paint = GetRandomInt(1, sizeof(gS_PaintColors) - 1);
-	}
+    if (paint == 0)
+    {
+        paint = GetRandomInt(1, sizeof(gS_PaintColors) - 1);
+    }
 
-	// Remove oldest paint if at limit (engine removes oldest decal automatically)
-	while (g_hPaintData[client].Length >= DECAL_LIMIT)
-	{
-		g_hPaintData[client].Erase(0);
-	}
+    // Remove oldest paint if at limit (engine removes oldest decal automatically)
+    while (g_hPaintData[client].Length >= DECAL_LIMIT)
+    {
+        g_hPaintData[client].Erase(0);
+    }
 
     PaintData data;
     data.x     = pos[0];
@@ -1435,22 +1440,22 @@ void AddPaint(int client, float pos[3], int paint = 0, int size = 0)
     data.size  = size;
     g_hPaintData[client].PushArray(data);
 
-	if(gB_PaintToAll[client])
-	{
-		TE_SetupWorldDecal(pos, gI_Sprites[paint - 1][size]);
-		TE_SendToAll();
-	}
-	else
-	{
-		TE_SetupWorldDecal(pos, gI_Sprites[paint - 1][size]);
-		TE_SendToClient(client);
-		
-		if(gI_Partner[client] != 0)
-		{
-			TE_SetupWorldDecal(pos, gI_Sprites[paint - 1][size]);
-			TE_SendToClient(gI_Partner[client]);
-		}		
-	}
+    if (gB_PaintToAll[client])
+    {
+        TE_SetupWorldDecal(pos, gI_Sprites[paint - 1][size]);
+        TE_SendToAll();
+    }
+    else
+    {
+        TE_SetupWorldDecal(pos, gI_Sprites[paint - 1][size]);
+        TE_SendToClient(client);
+
+        if (gI_Partner[client] != 0)
+        {
+            TE_SetupWorldDecal(pos, gI_Sprites[paint - 1][size]);
+            TE_SendToClient(gI_Partner[client]);
+        }
+    }
 }
 
 void RedrawPaints(int client)
@@ -1463,12 +1468,14 @@ void RedrawPaints(int client)
     g_hPaintData[client].Clear();
     g_iPaintLoadOffset[client] = 0;
 
-    RequestFrame(Frame_RedrawPaintBatch, client);
+    RequestFrame(Frame_RedrawPaintBatch, GetClientSerial(client));
 }
 
-public void Frame_RedrawPaintBatch(int client)
+public void Frame_RedrawPaintBatch(int serial)
 {
-    if (!IsClientInGame(client) || g_hPendingPaints[client] == null)
+    int client = GetClientFromSerial(serial);
+
+    if (!client || g_hPendingPaints[client] == null)
         return;
 
     int batchSize = 16;
@@ -1494,7 +1501,7 @@ public void Frame_RedrawPaintBatch(int client)
 
     if (end < total)
     {
-        RequestFrame(Frame_RedrawPaintBatch, client);
+        RequestFrame(Frame_RedrawPaintBatch, serial);
     }
     else
     {
@@ -1560,49 +1567,49 @@ void EracePaint(int client, float pos[3], int size = 0)
 
 int PrecachePaint(char[] filename)
 {
-	char tmpPath[PLATFORM_MAX_PATH];
-	Format(tmpPath, sizeof(tmpPath), "materials/%s", filename);
-	AddFileToDownloadsTable(tmpPath);
+    char tmpPath[PLATFORM_MAX_PATH];
+    Format(tmpPath, sizeof(tmpPath), "materials/%s", filename);
+    AddFileToDownloadsTable(tmpPath);
 
-	return PrecacheDecal(filename, true);
+    return PrecacheDecal(filename, true);
 }
 
 stock void TE_SetupWorldDecal(const float vecOrigin[3], int index)
 {
-	TE_Start("World Decal");
-	TE_WriteVector("m_vecOrigin", vecOrigin);
-	TE_WriteNum("m_nIndex", index);
+    TE_Start("World Decal");
+    TE_WriteVector("m_vecOrigin", vecOrigin);
+    TE_WriteNum("m_nIndex", index);
 }
 
 stock bool TraceEye(int client, float pos[3])
 {
-	float vAngles[3], vOrigin[3];
-	GetClientEyePosition(client, vOrigin);
-	GetClientEyeAngles(client, vAngles);
+    float vAngles[3], vOrigin[3];
+    GetClientEyePosition(client, vOrigin);
+    GetClientEyeAngles(client, vAngles);
 
-	TR_TraceRayFilter(vOrigin, vAngles, MASK_SHOT, RayType_Infinite, TraceEntityFilterPlayer);
+    TR_TraceRayFilter(vOrigin, vAngles, MASK_SHOT, RayType_Infinite, TraceEntityFilterPlayer);
 
-	if (TR_DidHit())
-	{
-		TR_GetEndPosition(pos);
-		return true;
-	}
+    if (TR_DidHit())
+    {
+        TR_GetEndPosition(pos);
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 stock void CaculatePlaneRotation(float rotation[3])
 {
-	TR_GetPlaneNormal(null, rotation);
-	
-	GetVectorAngles(rotation, rotation);
+    TR_GetPlaneNormal(null, rotation);
 
-	rotation[0] -= 270.0;
+    GetVectorAngles(rotation, rotation);
+
+    rotation[0] -= 270.0;
 }
 
 public bool TraceEntityFilterPlayer(int entity, int contentsMask)
 {
-	return (entity > MaxClients || !entity);
+    return (entity > MaxClients || !entity);
 }
 
 stock bool CheckClientAccess(int client)
@@ -1611,8 +1618,8 @@ stock bool CheckClientAccess(int client)
     gCV_AccessFlag.GetString(sFlag, sizeof(sFlag));
 
     int flags = ReadFlagString(sFlag);
-    
-    if((GetUserFlagBits(client) & flags) == flags)
+
+    if ((GetUserFlagBits(client) & flags) == flags)
     {
         return true;
     }
@@ -1622,60 +1629,60 @@ stock bool CheckClientAccess(int client)
 
 stock void GetPingColor(int index, int color[4])
 {
-	char sExploded[4][8];
-	ExplodeString(gS_PingColors[index][1], ";", sExploded, 4, 8);
+    char sExploded[4][8];
+    ExplodeString(gS_PingColors[index][1], ";", sExploded, 4, 8);
 
-	for (int i = 0; i < 4; i++)
-	{
-		color[i] = StringToInt(sExploded[i]);
-	}
+    for (int i = 0; i < 4; i++)
+    {
+        color[i] = StringToInt(sExploded[i]);
+    }
 }
 
 stock void SetClientCookieBool(int client, Handle cookie, bool value)
 {
-	SetClientCookie(client, cookie, value ? "1" : "0");
+    SetClientCookie(client, cookie, value ? "1" : "0");
 }
 
-stock bool GetClientCookieBool(int client, Handle cookie, bool& value)
+stock bool GetClientCookieBool(int client, Handle cookie, bool &value)
 {
-	char buffer[8];
-	GetClientCookie(client, cookie, buffer, sizeof(buffer));
+    char buffer[8];
+    GetClientCookie(client, cookie, buffer, sizeof(buffer));
 
-	if (buffer[0] == '\0')
-	{
-		return false;
-	}
+    if (buffer[0] == '\0')
+    {
+        return false;
+    }
 
-	value = StringToInt(buffer) != 0;
-	return true;
+    value = StringToInt(buffer) != 0;
+    return true;
 }
 
 stock void SetClientCookieInt(int client, Handle cookie, int value)
 {
-	char buffer[8];
-	IntToString(value, buffer, 8);
-	SetClientCookie(client, cookie, buffer);
+    char buffer[8];
+    IntToString(value, buffer, 8);
+    SetClientCookie(client, cookie, buffer);
 }
 
-stock bool GetClientCookieInt(int client, Handle cookie, int& value)
+stock bool GetClientCookieInt(int client, Handle cookie, int &value)
 {
-	char buffer[8];
-	GetClientCookie(client, cookie, buffer, sizeof(buffer));
-	if (buffer[0] == '\0')
-	{
-		return false;
-	}
+    char buffer[8];
+    GetClientCookie(client, cookie, buffer, sizeof(buffer));
+    if (buffer[0] == '\0')
+    {
+        return false;
+    }
 
-	value = StringToInt(buffer);
-	return true;
+    value = StringToInt(buffer);
+    return true;
 }
 
 stock void AddFilesToDownloadsTable()
 {
-	char sPath[PLATFORM_MAX_PATH];
-	FormatEx(sPath, sizeof(sPath), "sound/%s", PING_SOUND_PATH);
+    char sPath[PLATFORM_MAX_PATH];
+    FormatEx(sPath, sizeof(sPath), "sound/%s", PING_SOUND_PATH);
 
-	AddFileToDownloadsTable(sPath);
+    AddFileToDownloadsTable(sPath);
     AddFileToDownloadsTable("materials/decals/paint/paint_decal.vtf");
     AddFileToDownloadsTable("materials/decals/paint/paint_eraser.vtf");
 
@@ -1698,19 +1705,19 @@ stock void AddFilesToDownloadsTable()
         AddFileToDownloadsTable(buffer);
     }
 
-	AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_arrow.vtf");
-	AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_arrow.vmt");
-	AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_point.vtf");
-	AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_point.vmt");
-	AddFileToDownloadsTable("materials/expert_zone/pingtool/grad.vtf");
-	AddFileToDownloadsTable("materials/expert_zone/pingtool/grad.vmt");
-	AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.dx80.vtx");
-	AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.dx90.vtx");
-	AddFileToDownloadsTable(PING_MODEL_PATH);
-	AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.sw.vtx");
-	AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.vvd");
-	PrecacheModel(PING_MODEL_PATH);
-	PrecacheSound(PING_SOUND_PATH);
+    AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_arrow.vtf");
+    AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_arrow.vmt");
+    AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_point.vtf");
+    AddFileToDownloadsTable("materials/expert_zone/pingtool/circle_point.vmt");
+    AddFileToDownloadsTable("materials/expert_zone/pingtool/grad.vtf");
+    AddFileToDownloadsTable("materials/expert_zone/pingtool/grad.vmt");
+    AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.dx80.vtx");
+    AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.dx90.vtx");
+    AddFileToDownloadsTable(PING_MODEL_PATH);
+    AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.sw.vtx");
+    AddFileToDownloadsTable("models/expert_zone/pingtool/pingtool.vvd");
+    PrecacheModel(PING_MODEL_PATH);
+    PrecacheSound(PING_SOUND_PATH);
 }
 
 public void Shavit_OnDatabaseLoaded()
@@ -1735,26 +1742,32 @@ public Action Command_PaintSave(int client, int args)
 {
     if (gH_SQL == null)
     {
-        Shavit_PrintToChat(client, "Database not connected.");
+        Shavit_PrintToChat(client, "%T", "DatabaseNotConnected", client);
         return Plugin_Handled;
     }
 
     if (g_hPendingPaints[client] != null)
     {
-        Shavit_PrintToChat(client, "Cannot save while loading paints.");
+        Shavit_PrintToChat(client, "%T", "SaveWait", client);
+        return Plugin_Handled;
+    }
+
+    if (GetEngineTime() - g_fLastSaveLoad[client] < PAINT_SAVE_LOAD_COOLDOWN)
+    {
+        Shavit_PrintToChat(client, "%T", "SaveCooldown", client, PAINT_SAVE_LOAD_COOLDOWN - (GetEngineTime() - g_fLastSaveLoad[client]));
         return Plugin_Handled;
     }
 
     if (g_hPaintData[client] == null || g_hPaintData[client].Length == 0)
     {
-        Shavit_PrintToChat(client, "You have no paints to save.");
+        Shavit_PrintToChat(client, "%T", "NoPaintsToSave", client);
         return Plugin_Handled;
     }
 
     char sAuth[64];
     if (!GetClientAuthId(client, AuthId_Engine, sAuth, sizeof(sAuth)))
     {
-        Shavit_PrintToChat(client, "Failed to get SteamID.");
+        Shavit_PrintToChat(client, "%T", "SteamIDFail", client);
         return Plugin_Handled;
     }
 
@@ -1765,7 +1778,9 @@ public Action Command_PaintSave(int client, int args)
     FormatEx(sQuery, sizeof(sQuery), "DELETE FROM `%spaints` WHERE auth = '%s' AND map = '%s';", gS_MySQLPrefix, sAuth, sMap);
     gH_SQL.Query(SQL_OnDeleteBeforeSave, sQuery, GetClientUserId(client));
 
-    Shavit_PrintToChat(client, "Saving paints...");
+    g_fLastSaveLoad[client] = GetEngineTime();
+
+    Shavit_PrintToChat(client, "%T", "SavingPaints", client);
 
     return Plugin_Handled;
 }
@@ -1777,7 +1792,7 @@ public void SQL_OnDeleteBeforeSave(Database db, DBResultSet results, const char[
 
     if (results == null)
     {
-        Shavit_PrintToChat(client, "Save failed (Delete Error): %s", error);
+        Shavit_PrintToChat(client, "%T", "SaveFailed", client, error);
         LogError("Save Delete Error: %s", error);
         return;
     }
@@ -1810,7 +1825,7 @@ public void SQL_OnSaveComplete(Database db, any data, int numQueries, Handle[] r
     int client = GetClientOfUserId(data);
     if (client)
     {
-        Shavit_PrintToChat(client, "Paints saved successfully!");
+        Shavit_PrintToChat(client, "%T", "PaintsSaved", client);
     }
 }
 
@@ -1818,13 +1833,19 @@ public Action Command_PaintLoad(int client, int args)
 {
     if (gH_SQL == null)
     {
-        Shavit_PrintToChat(client, "Database not connected.");
+        Shavit_PrintToChat(client, "%T", "DatabaseNotConnected", client);
         return Plugin_Handled;
     }
 
     if (g_hPendingPaints[client] != null)
     {
-        Shavit_PrintToChat(client, "Already loading paints, please wait.");
+        Shavit_PrintToChat(client, "%T", "LoadWait", client);
+        return Plugin_Handled;
+    }
+
+    if (GetEngineTime() - g_fLastSaveLoad[client] < PAINT_SAVE_LOAD_COOLDOWN)
+    {
+        Shavit_PrintToChat(client, "%T", "LoadCooldown", client, PAINT_SAVE_LOAD_COOLDOWN - (GetEngineTime() - g_fLastSaveLoad[client]));
         return Plugin_Handled;
     }
 
@@ -1837,6 +1858,8 @@ public Action Command_PaintLoad(int client, int args)
     FormatEx(sQuery, sizeof(sQuery), "SELECT x, y, z, color, size FROM `%spaints` WHERE auth = '%s' AND map = '%s';", gS_MySQLPrefix, sAuth, sMap);
     gH_SQL.Query(SQL_OnPaintLoad, sQuery, GetClientUserId(client));
 
+    g_fLastSaveLoad[client] = GetEngineTime();
+
     return Plugin_Handled;
 }
 
@@ -1848,13 +1871,13 @@ public void SQL_OnPaintLoad(Database db, DBResultSet results, const char[] error
     if (results == null)
     {
         LogError("Paint load failed: %s", error);
-        Shavit_PrintToChat(client, "Failed to load paints.");
+        Shavit_PrintToChat(client, "%T", "FailedToLoadPaints", client);
         return;
     }
 
     if (results.RowCount == 0)
     {
-        Shavit_PrintToChat(client, "No saved paints found for this map.");
+        Shavit_PrintToChat(client, "%T", "NoSavedPaints", client);
         return;
     }
 
@@ -1892,18 +1915,22 @@ public void SQL_OnPaintLoad(Database db, DBResultSet results, const char[] error
 
     if (loadCount == 0)
     {
-        Shavit_PrintToChat(client, "No paints to load.");
+        Shavit_PrintToChat(client, "%T", "NoPaintsToLoad", client);
+        delete g_hPendingPaints[client];
+        g_hPendingPaints[client] = null;
         return;
     }
 
     g_iPaintLoadOffset[client] = 0;
-    Shavit_PrintToChat(client, "Loading %d paints...", loadCount);
-    RequestFrame(Frame_LoadPaintBatch, client);
+    Shavit_PrintToChat(client, "%T", "LoadingPaints", client, loadCount);
+    RequestFrame(Frame_LoadPaintBatch, GetClientSerial(client));
 }
 
-public void Frame_LoadPaintBatch(int client)
+public void Frame_LoadPaintBatch(int serial)
 {
-    if (!IsClientInGame(client) || g_hPendingPaints[client] == null)
+    int client = GetClientFromSerial(serial);
+
+    if (!client || g_hPendingPaints[client] == null)
         return;
 
     int batchSize = 16;
@@ -1931,11 +1958,11 @@ public void Frame_LoadPaintBatch(int client)
 
     if (end < total)
     {
-        RequestFrame(Frame_LoadPaintBatch, client);
+        RequestFrame(Frame_LoadPaintBatch, serial);
     }
     else
     {
-        Shavit_PrintToChat(client, "Loaded %d paints.", total);
+        Shavit_PrintToChat(client, "%T", "LoadedPaints", client, total);
         delete g_hPendingPaints[client];
         g_hPendingPaints[client]   = null;
         g_iPaintLoadOffset[client] = 0;
@@ -1964,7 +1991,7 @@ public Action Command_PaintDelete(int client, int args)
 public void SQL_OnDeleteComplete(Database db, DBResultSet results, const char[] error, any data)
 {
     int client = GetClientOfUserId(data);
-    if (client) Shavit_PrintToChat(client, "Paints deleted.");
+    if (client) Shavit_PrintToChat(client, "%T", "PaintsDeleted", client);
 }
 
 void OpenConfirmMenu(int client, int action)

--- a/addons/sourcemod/translations/shavit-mark.phrases.txt
+++ b/addons/sourcemod/translations/shavit-mark.phrases.txt
@@ -314,4 +314,34 @@
 	{
 		"en"		"Turquoise"
 	}
+    "PaintSave"
+    {
+        "en"
+        "Save Paints"
+    }
+    "PaintLoad"
+    {
+        "en"
+        "Load Paints"
+    }
+    "PaintDelete"
+    {
+        "en"
+        "Delete Saved Paints"
+    }
+    "ConfirmAction"
+    {
+        "en"
+        "Are you sure?"
+    }
+    "ConfirmYes"
+    {
+        "en"
+        "Yes"
+    }
+    "ConfirmNo"
+    {
+        "en"
+        "No"
+    }
 }

--- a/addons/sourcemod/translations/shavit-mark.phrases.txt
+++ b/addons/sourcemod/translations/shavit-mark.phrases.txt
@@ -1,319 +1,405 @@
 "Phrases"
 {
-	"PingMenuTitle"
-	{
-		"en"		"Ping Menu"
-	}
-	"PingTips"
-	{
-		"en"		"Use command \"sm_ping\" to mark a position"
-	}
-	"CreatePingMarker"
-	{
-		"en"		"Create ping marker"
-	}
-	"RemovePingMarker"
-	{
-		"en"		"Remove ping marker"
-	}
-	"PingOptions"
-	{
-		"en"		"Options"
-	}
-	"PingOptionMenuTitle"
-	{
-		"en"		"Ping Options"
-	}
-	"PingDuration"
-	{
-		"en"		"Ping Duration"
-	}
-	"DurationLong"
-	{
-		"en"		"Until Next Ping"
-	}
-	"DurationShort"
-	{
-		"#format"	"{1:d}"
-		"en"		"Last {1} Seconds"
-	}
-	"PingColor"
-	{
-		"en"		"Ping Color"
-	}
-	"PingSound"
-	{
-		"en"		"Ping Sound"
-	}
-	"PingObject"
-	{
-		"en"		"Ping Object"
-	}
-	"PingColorMenuTitle"
-	{
-		"en"		"Ping Color"
-	}
-	"PaintMenuTitle"
-	{
-		"en"		"Paint Menu"
-	}
-	"PaintTips"
-	{
-		"en"		"Tips: Excute: bind <KEY> \"+paint\" in consle to bind a key to paint"
-	}
-	"ModeContinuous"
-	{
-		"en"		"Continuous"
-	}
-	"ModeSingle"
-	{
-		"en"		"Single"
-	}
-	"TogglePaint"
-	{
-		"en"		"Paint"
-	}
-	"PaintMode"
-	{
-		"en"		"Paint Mode"
-	}
-	"ToggleErase"
-	{
-		"en"		"Erase"
-	}
-	"PaintColor"
-	{
-		"en"		"Paint Color"
-	}
-	"PaintSize"
-	{
-		"en"		"Paint Size"
-	}
-	"PaintObject"
-	{
-		"en"		"Paint Object"
-	}
-	"PaintOptions"
-	{
-		"en"		"Paint Options"
-	}
-	"PaintOptionMenuTitle"
-	{
-		"en"		"Paint Options"
-	}
-	"PaintEraser"
-	{	
-		"en"		"Paint Eraser"
-	}
-	"EraserOn"
-	{
-		"en"		"ON"
-	}
-	"EraserOff"
-	{
-		"en"		"OFF"
-	}
-	"ObjectAll"
-	{
-		"en"		"All players"
-	}
-	"ObjectSingle"
-	{
-		"en"		"Own"
-	}
-	"PaintSelectPartner"
-	{
-		"en"		"Select a partner"
-	}
-	"NoPartner"
-	{
-		"en"		"You are not partnered with anyone."
-	}
-	"Refresh"
-	{
-		"en"		"Refresh"
-	}
-	"ReceivePartnerRequest"
-	{
-		"en"		"Receive partner requests"
-	}
-	"RemovePartner"
-	{
-		"en"		"Remove partner"
-	}
-	"SendPartnerRequest"
-	{
-		"en"		"Send request to a player"
-	}
-	"NoPartnerFound"
-	{
-		"en"		"No partner found"
-	}
-	"RequestSent"
-	{
-		"en"		"Request sent."
-	}
-	"ResponseWaitingMenuTitle"
-	{
-		"#format"	"{1:s}"
-		"en"		"Waiting response from {1}"
-	}
-	"ReceivedRequest"
-	{
-		"#format"	"{1:s}"
-		"en"		"Received paint partner request from {1}"
-	}
-	"AcceptRequest"
-	{
-		"en"		"Accept"
-	}
-	"DeclineRequest"
-	{
-		"en"		"Decline"
-	}
-	"CancelRequest"
-	{
-		"en"		"Cancel"
-	}
-	"MenuAutoClose"
-	{
-		"en"		"Menu will close in 10 seconds..."
-	}
-	"MenuClose"
-	{
-		"en"		"Close"
-	}
-	"RequestAccepted"
-	{
-		"#format"	"{1:s}"
-		"en"		"Your request has been accepted by {1}"
-	}
-	"RequestDeclined"
-	{
-		"#format"	"{1:s}"
-		"en"		"Your request has been declined by {1}"
-	}
-	"RequestCanceled"
-	{
-		"#format"	"{1:s}"
-		"en"		"This request has been canceled by {1}"
-	}
-	"RequestAborted"
-	{
-		"#format"	"{1:s}"
-		"en"		"Partnering with {1} aborted"
-	}
-	"Partnered"
-	{
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"Your are now partnered with {1}{2}{3}."
-	}
-	"Unpartnered"
-	{
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"Your are no longer partnered with {1}{2}{3}."
-	}
-	"PartnerDisconnected"
-	{
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"Your partner {1}{2}{3} has disconnected."
-	}
-	"PaintModeChangeError"
-	{
-		"en"		"You cannot change paint mode while painting."
-	}
-	"PaintClear"
-	{
-		"en"		"Clear Paint"
-	}
-	"PaintCleared"
-	{
-		"en"		"Paint has been cleared."
-	}
-	"PaintColorMenuTitle"
-	{
-		"en"		"Select A Color: "
-	}
-	"PaintSizeMenuTitle"
-	{
-		"en"		"Select A Size: "
-	}
-	"PaintSizeSmall"
-	{
-		"en"		"Small"
-	}
-	"PaintSizeMedium"
-	{
-		"en"		"Medium"
-	}
-	"PaintSizeLarge"
-	{
-		"en"		"Large"
-	}
-	"ColorRandom"
-	{
-		"en"		"Random"
-	}
-	"ColorWhite"
-	{
-		"en"		"White"
-	}
-	"ColorBlack"
-	{
-		"en"		"Black"
-	}
-	"ColorBlue"
-	{
-		"en"		"Blue"
-	}
-	"ColorLightBlue"
-	{
-		"en"		"Light Blue"
-	}
-	"ColorBrown"
-	{
-		"en"		"Brown"
-	}
-	"ColorCyan"
-	{
-		"en"		"Cyan"
-	}
-	"ColorGreen"
-	{
-		"en"		"Green"
-	}
-	"ColorDarkGreen"
-	{
-		"en"		"Dark Green"
-	}
-	"ColorRed"
-	{
-		"en"		"Red"
-	}
-	"ColorOrange"
-	{
-		"en"		"Orange"
-	}
-	"ColorYellow"
-	{
-		"en"		"Yellow"
-	}
-	"ColorPink"
-	{
-		"en"		"Pink"
-	}
-	"ColorLightPink"
-	{
-		"en"		"Light Pink"
-	}
-	"ColorPurple"
-	{
-		"en"		"Purple"
-	}
-	"ColorTurquoise"
-	{
-		"en"		"Turquoise"
-	}
+    "PingMenuTitle"
+    {
+        "en"
+        "Ping Menu"
+    }
+    "PingTips"
+    {
+        "en"
+        "Use command \"sm_ping\" to mark a position"
+    }
+    "CreatePingMarker"
+    {
+        "en"
+        "Create ping marker"
+    }
+    "RemovePingMarker"
+    {
+        "en"
+        "Remove ping marker"
+    }
+    "PingOptions"
+    {
+        "en"
+        "Options"
+    }
+    "PingOptionMenuTitle"
+    {
+        "en"
+        "Ping Options"
+    }
+    "PingDuration"
+    {
+        "en"
+        "Ping Duration"
+    }
+    "DurationLong"
+    {
+        "en"
+        "Until Next Ping"
+    }
+    "DurationShort"
+    {
+        "#format"
+        "{1:d}"
+        "en"
+        "Last {1} Seconds"
+    }
+    "PingColor"
+    {
+        "en"
+        "Ping Color"
+    }
+    "PingSound"
+    {
+        "en"
+        "Ping Sound"
+    }
+    "PingObject"
+    {
+        "en"
+        "Ping Object"
+    }
+    "PingColorMenuTitle"
+    {
+        "en"
+        "Ping Color"
+    }
+    "PaintMenuTitle"
+    {
+        "en"
+        "Paint Menu"
+    }
+    "PaintTips"
+    {
+        "en"
+        "Tips: Excute: bind <KEY> \"+paint\" in consle to bind a key to paint"
+    }
+    "ModeContinuous"
+    {
+        "en"
+        "Continuous"
+    }
+    "ModeSingle"
+    {
+        "en"
+        "Single"
+    }
+    "TogglePaint"
+    {
+        "en"
+        "Paint"
+    }
+    "PaintMode"
+    {
+        "en"
+        "Paint Mode"
+    }
+    "ToggleErase"
+    {
+        "en"
+        "Erase"
+    }
+    "PaintColor"
+    {
+        "en"
+        "Paint Color"
+    }
+    "PaintSize"
+    {
+        "en"
+        "Paint Size"
+    }
+    "PaintObject"
+    {
+        "en"
+        "Paint Object"
+    }
+    "PaintOptions"
+    {
+        "en"
+        "Paint Options"
+    }
+    "PaintOptionMenuTitle"
+    {
+        "en"
+        "Paint Options"
+    }
+    "PaintEraser"
+    {
+        "en"
+        "Paint Eraser"
+    }
+    "EraserOn"
+    {
+        "en"
+        "ON"
+    }
+    "EraserOff"
+    {
+        "en"
+        "OFF"
+    }
+    "ObjectAll"
+    {
+        "en"
+        "All players"
+    }
+    "ObjectSingle"
+    {
+        "en"
+        "Own"
+    }
+    "PaintSelectPartner"
+    {
+        "en"
+        "Select a partner"
+    }
+    "NoPartner"
+    {
+        "en"
+        "You are not partnered with anyone."
+    }
+    "Refresh"
+    {
+        "en"
+        "Refresh"
+    }
+    "ReceivePartnerRequest"
+    {
+        "en"
+        "Receive partner requests"
+    }
+    "RemovePartner"
+    {
+        "en"
+        "Remove partner"
+    }
+    "SendPartnerRequest"
+    {
+        "en"
+        "Send request to a player"
+    }
+    "NoPartnerFound"
+    {
+        "en"
+        "No partner found"
+    }
+    "RequestSent"
+    {
+        "en"
+        "Request sent."
+    }
+    "ResponseWaitingMenuTitle"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Waiting response from {1}"
+    }
+    "ReceivedRequest"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Received paint partner request from {1}"
+    }
+    "AcceptRequest"
+    {
+        "en"
+        "Accept"
+    }
+    "DeclineRequest"
+    {
+        "en"
+        "Decline"
+    }
+    "CancelRequest"
+    {
+        "en"
+        "Cancel"
+    }
+    "MenuAutoClose"
+    {
+        "en"
+        "Menu will close in 10 seconds..."
+    }
+    "MenuClose"
+    {
+        "en"
+        "Close"
+    }
+    "RequestAccepted"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Your request has been accepted by {1}"
+    }
+    "RequestDeclined"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Your request has been declined by {1}"
+    }
+    "RequestCanceled"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "This request has been canceled by {1}"
+    }
+    "RequestAborted"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Partnering with {1} aborted"
+    }
+    "Partnered"
+    {
+        "#format"
+        "{1:s},{2:s},{3:s}"
+        "en"
+        "Your are now partnered with {1}{2}{3}."
+    }
+    "Unpartnered"
+    {
+        "#format"
+        "{1:s},{2:s},{3:s}"
+        "en"
+        "Your are no longer partnered with {1}{2}{3}."
+    }
+    "PartnerDisconnected"
+    {
+        "#format"
+        "{1:s},{2:s},{3:s}"
+        "en"
+        "Your partner {1}{2}{3} has disconnected."
+    }
+    "PaintModeChangeError"
+    {
+        "en"
+        "You cannot change paint mode while painting."
+    }
+    "PaintClear"
+    {
+        "en"
+        "Clear Paint"
+    }
+    "PaintCleared"
+    {
+        "en"
+        "Paint has been cleared."
+    }
+    "PaintColorMenuTitle"
+    {
+        "en"
+        "Select A Color: "
+    }
+    "PaintSizeMenuTitle"
+    {
+        "en"
+        "Select A Size: "
+    }
+    "PaintSizeSmall"
+    {
+        "en"
+        "Small"
+    }
+    "PaintSizeMedium"
+    {
+        "en"
+        "Medium"
+    }
+    "PaintSizeLarge"
+    {
+        "en"
+        "Large"
+    }
+    "ColorRandom"
+    {
+        "en"
+        "Random"
+    }
+    "ColorWhite"
+    {
+        "en"
+        "White"
+    }
+    "ColorBlack"
+    {
+        "en"
+        "Black"
+    }
+    "ColorBlue"
+    {
+        "en"
+        "Blue"
+    }
+    "ColorLightBlue"
+    {
+        "en"
+        "Light Blue"
+    }
+    "ColorBrown"
+    {
+        "en"
+        "Brown"
+    }
+    "ColorCyan"
+    {
+        "en"
+        "Cyan"
+    }
+    "ColorGreen"
+    {
+        "en"
+        "Green"
+    }
+    "ColorDarkGreen"
+    {
+        "en"
+        "Dark Green"
+    }
+    "ColorRed"
+    {
+        "en"
+        "Red"
+    }
+    "ColorOrange"
+    {
+        "en"
+        "Orange"
+    }
+    "ColorYellow"
+    {
+        "en"
+        "Yellow"
+    }
+    "ColorPink"
+    {
+        "en"
+        "Pink"
+    }
+    "ColorLightPink"
+    {
+        "en"
+        "Light Pink"
+    }
+    "ColorPurple"
+    {
+        "en"
+        "Purple"
+    }
+    "ColorTurquoise"
+    {
+        "en"
+        "Turquoise"
+    }
     "PaintSave"
     {
         "en"
@@ -343,5 +429,102 @@
     {
         "en"
         "No"
+    }
+    "DatabaseNotConnected"
+    {
+        "en"
+        "Database not connected."
+    }
+    "SaveWait"
+    {
+        "en"
+        "Cannot save while loading paints."
+    }
+    "SaveCooldown"
+    {
+        "#format"
+        "{1:.1f}"
+        "en"
+        "Please wait {1} seconds before saving again."
+    }
+    "NoPaintsToSave"
+    {
+        "en"
+        "You have no paints to save."
+    }
+    "SteamIDFail"
+    {
+        "en"
+        "Failed to get SteamID."
+    }
+    "SavingPaints"
+    {
+        "en"
+        "Saving paints..."
+    }
+    "SaveFailed"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Save failed (Delete Error): {1}"
+    }
+    "PaintsSaved"
+    {
+        "en"
+        "Paints saved successfully!"
+    }
+    "LoadWait"
+    {
+        "en"
+        "Already loading paints, please wait."
+    }
+    "LoadCooldown"
+    {
+        "#format"
+        "{1:.1f}"
+        "en"
+        "Please wait {1} seconds before loading again."
+    }
+    "PaintLoadFailed"
+    {
+        "#format"
+        "{1:s}"
+        "en"
+        "Paint load failed: {1}"
+    }
+    "FailedToLoadPaints"
+    {
+        "en"
+        "Failed to load paints."
+    }
+    "NoSavedPaints"
+    {
+        "en"
+        "No saved paints found for this map."
+    }
+    "NoPaintsToLoad"
+    {
+        "en"
+        "No paints to load."
+    }
+    "LoadingPaints"
+    {
+        "#format"
+        "{1:d}"
+        "en"
+        "Loading {1} paints..."
+    }
+    "LoadedPaints"
+    {
+        "#format"
+        "{1:d}"
+        "en"
+        "Loaded {1} paints."
+    }
+    "PaintsDeleted"
+    {
+        "en"
+        "Paints deleted."
     }
 }


### PR DESCRIPTION
Add functionality to save, load, and delete player paint data to/from the shavit timer database.

Changes:
- Connect to shavit's database via Shavit_GetDatabase() and use the shared table prefix from GetTimerSQLPrefix()
- Create new `{prefix}paints` table for storing paint coordinates
- Add commands: !paintsave, !paintload, !paintdelete (with aliases)
- Add Save/Load/Delete menu items to paint menu (!paint)
- Add confirmation dialog for Clear and Delete actions
- Implement batch loading (16 paints/frame) due to Source engine (TempEnt limit per frame)
- Track paint data in per-client ArrayList during session
- Add translation phrases for new menu items

Database table schema:
- id (INT AUTO_INCREMENT)
- auth (VARCHAR 64) - player SteamID
- map (VARCHAR 128) - map name
- x, y, z (FLOAT) - paint coordinates
- color, size (INT) - paint settings